### PR TITLE
Refactor Measurement Units to Use Constants in Mammotion Sensor

### DIFF
--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from pymammotion.data.model.device import MowingDevice
 from pymammotion.mammotion.devices import MammotionBaseBLEDevice
 from pymammotion.proto.luba_msg import LubaMsg
 
@@ -66,7 +67,7 @@ class MammotionDataUpdateCoordinator(DataUpdateCoordinator[LubaMsg]):
         """Get map data from the device."""
         await self.device.start_map_sync()
 
-    async def _async_update_data(self) -> LubaMsg:
+    async def _async_update_data(self) -> MowingDevice:
         """Get data from the device."""
         if not (
             ble_device := bluetooth.async_ble_device_from_address(

--- a/custom_components/mammotion/sensor.py
+++ b/custom_components/mammotion/sensor.py
@@ -9,7 +9,8 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfLength, AREA_SQUARE_METERS, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, \
+    UnitOfSpeed, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -41,14 +42,14 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         key="ble_rssi",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        native_unit_of_measurement="dBm",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         value_fn=lambda mower_data: mower_data.connect.ble_rssi,
     ),
     MammotionSensorEntityDescription(
         key="wifi_rssi",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        native_unit_of_measurement="dBm",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         value_fn=lambda mower_data: mower_data.connect.wifi_rssi,
     ),
     MammotionSensorEntityDescription(
@@ -62,21 +63,21 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         key="blade_height",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=None,
-        native_unit_of_measurement="mm",
+        native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         value_fn=lambda mower_data: mower_data.work.knife_height,
     ),
     MammotionSensorEntityDescription(
         key="area",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=None,
-        native_unit_of_measurement="m²",
+        native_unit_of_measurement=AREA_SQUARE_METERS,
         value_fn=lambda mower_data: mower_data.work.area & 65535,
     ),
     MammotionSensorEntityDescription(
         key="mowing_speed",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.SPEED,
-        native_unit_of_measurement="m/s",
+        native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         value_fn=lambda mower_data: mower_data.work.man_run_speed / 100,
     ),
     MammotionSensorEntityDescription(
@@ -90,14 +91,14 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         key="total_time",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement="min",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: mower_data.work.progress & 65535,
     ),
     MammotionSensorEntityDescription(
         key="elapsed_time",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement="min",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: (mower_data.work.progress & 65535)
         - (mower_data.work.progress >> 16),
     ),
@@ -105,7 +106,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         key="left_time",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement="min",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: mower_data.work.progress >> 16,
     ),
     MammotionSensorEntityDescription(


### PR DESCRIPTION
### **Description**
- Refactored measurement units in `MammotionSensorEntityDescription` to use constants from `homeassistant.const`.
- Improved code maintainability and readability by replacing hardcoded unit strings with constants.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Refactor Measurement Units to Use Constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/sensor.py
<li>Updated measurement units to use constants from <code>homeassistant.const</code>.<br> <li> Replaced string literals for units with appropriate constants for <br>better clarity and maintainability.<br> <li> Enhanced the readability of the code by using predefined unit <br>constants.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/57/files#diff-7292910294107715a17e2f76db255b5fceef123e43166bb3eb85a2bc4b748840">+10/-9</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>