### PR TITLE
Fix condition for WiFi step in config_flow.py

### DIFF
--- a/custom_components/mammotion/config_flow.py
+++ b/custom_components/mammotion/config_flow.py
@@ -117,7 +117,7 @@ class MammotionConfigFlow(ConfigFlow, domain=DOMAIN):
                 continue
             self._discovered_devices[address] = discovery_info.name
 
-        if not self._discovered_devices:
+        if not self._discovered_devices and user_input is not None:
             return await self.async_step_wifi(user_input)
 
         return self.async_show_form(


### PR DESCRIPTION
### **User description**
Hi,
Here a patch for this error :
![image](https://github.com/user-attachments/assets/e6ceb69a-db61-43ba-8777-391c67402333)


___

### **Description**
- Fixes a logic error that caused a 500 Internal Server Error when no devices were discovered.
- Ensures that the WiFi step is only reached if `user_input` is provided.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Fix condition for proceeding to WiFi step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/config_flow.py
<li>Added a condition to check if <code>user_input</code> is not None.<br> <li> Prevents proceeding to the WiFi step if no devices are discovered and <br><code>user_input</code> is None.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/77/files#diff-8c3bcec77455f7b2c6cba532248bb46b24164f10f7b47c062fe6af952221aba5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>