### PR TITLE
Fix crash without Bluetooth availability

### DIFF
--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -122,7 +122,7 @@ class MammotionDataUpdateCoordinator(DataUpdateCoordinator[MowingDevice]):
             if preference is ConnectionPreference.WIFI and device.cloud():
                 device.cloud().on_ready_callback = lambda: device.cloud().start_sync(0)
                 device.cloud().set_notification_callback(self._async_update_cloud)
-            elif device.ble():
+            elif ble_device:
                 await device.ble().start_sync(0)
             else:
                 raise ConfigEntryNotReady("No configuration available to setup Mammotion lawn mower")


### PR DESCRIPTION
### **User description**
Fixes #105


___

### **Description**
- Fixes a crash that occurs when Bluetooth is not available by using the `ble_device` variable.
- Enhances error handling during the setup of the Mammotion lawn mower.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Fix crash when Bluetooth is not available</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/coordinator.py
<li>Replaced <code>device.ble()</code> check with <code>ble_device</code> variable.<br> <li> Improved error handling for device setup.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/106/files#diff-f8a4a06ede7f30cde21a849be8db19504f7080576f20551e2d0a9c5a7d1d2756">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>