### PR TITLE
Enhance LawnMower State Management and Error Handling

### DIFF
--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -97,7 +97,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         ):
             try:
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_cancel_failed"
+                    trans_key = "pause_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                     await self.coordinator.async_request_iot_sync()
                     # TODO is rpt_dev_status updated on iot sync?
@@ -147,7 +147,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     await self.coordinator.async_request_iot_sync()
 
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_cancel_failed"
+                    trans_key = "pause_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                 else:
                     trans_key = "dock_failed"
@@ -180,7 +180,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("pause_execute_task")
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_cancel_failed"
+                    trans_key = "pause_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -150,7 +150,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     async def async_start_mowing(self, **kwargs: Any) -> None:
         """Start mowing."""
         
-        operational_settings = self.coordinator.operation_settings
         if kwargs:
             entity_ids = kwargs.get("areas", [])
 
@@ -180,7 +179,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         ):
             try:
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "pause_failed"
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                     await self.coordinator.async_request_iot_sync()
                     # TODO is rpt_dev_status updated on iot sync?
@@ -227,7 +226,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     await self.coordinator.async_request_iot_sync()
 
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "pause_failed"
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                 else:
                     trans_key = "dock_failed"
@@ -257,7 +256,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("pause_execute_task")
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "pause_failed"
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -149,6 +149,8 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
 
     async def async_start_mowing(self, **kwargs: Any) -> None:
         """Start mowing."""
+        
+        operational_settings = self.coordinator.operation_settings
         if kwargs:
             entity_ids = kwargs.get("areas", [])
 
@@ -160,10 +162,8 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             kwargs["areas"] = attributes
             operational_settings = OperationSettings.from_dict(kwargs)
             LOGGER.debug(kwargs)
-            await self.coordinator.async_plan_route(operational_settings)
-            await self.coordinator.async_send_command("start_job")
-            await self.coordinator.async_request_iot_sync()
-            return
+        else:
+            operational_settings = self.coordinator.operation_settings
 
         # check if job in progress
         #
@@ -191,7 +191,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     await self.coordinator.async_send_command("resume_execute_task")
                 if mode == WorkMode.MODE_READY:
                     trans_key = "start_failed"
-                    await self.coordinator.async_plan_route(self.coordinator.operation_settings)
+                    await self.coordinator.async_plan_route(operational_settings)
                     await self.coordinator.async_send_command("start_job")
                 
             except COMMAND_EXCEPTIONS as exc:

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -72,10 +72,8 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             and charge_state == 0)
         ):
             return LawnMowerActivity.PAUSED
-        if mode == WorkMode.MODE_WORKING:
+        if mode in (WorkMode.MODE_WORKING, WorkMode.MODE_RETURNING):
             return LawnMowerActivity.MOWING
-        if mode == WorkMode.MODE_RETURNING:
-            return LawnMowerActivity.RETURNING
         if mode == WorkMode.MODE_LOCK:
             return LawnMowerActivity.ERROR
         if mode == WorkMode.MODE_READY and charge_state != 0:

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -228,7 +228,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 if mode == WorkMode.MODE_WORKING:
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("pause_execute_task")
-                    await self.coordinator.async_request_iot_sync()
 
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_cancel_failed"

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -60,21 +60,22 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     def activity(self) -> LawnMowerActivity | None:
         """Return the state of the mower."""
 
-        if self.rpt_dev_status is None:
-            return None
-
-        mode = self.rpt_dev_status.sys_status
         charge_state = self.rpt_dev_status.charge_state
+        mode = self.rpt_dev_status.sys_status
+        if mode is None:
+            return None
 
         LOGGER.debug("activity mode %s", mode)
         if (
             mode == WorkMode.MODE_PAUSE
-            or mode == WorkMode.MODE_READY
-            and charge_state == 0
+            or (mode == WorkMode.MODE_READY
+            and charge_state == 0)
         ):
             return LawnMowerActivity.PAUSED
-        if mode in (WorkMode.MODE_WORKING, WorkMode.MODE_RETURNING):
+        if mode == WorkMode.MODE_WORKING:
             return LawnMowerActivity.MOWING
+        if mode == WorkMode.MODE_RETURNING:
+            return LawnMowerActivity.RETURNING
         if mode == WorkMode.MODE_LOCK:
             return LawnMowerActivity.ERROR
         if mode == WorkMode.MODE_READY and charge_state != 0:

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -238,7 +238,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 ) from exc
             finally:
                 await self.coordinator.async_request_iot_sync()
-                self.coordinator.async_set_updated_data(
 
     async def async_pause(self) -> None:
         """Pause mower."""

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -200,9 +200,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 ) from exc
             finally:
                 await self.coordinator.async_request_iot_sync()
-                self.coordinator.async_set_updated_data(
-                    self.coordinator.manager.mower(self.coordinator.device_name)
-                )
 
     async def async_dock(self) -> None:
         """Start docking."""
@@ -242,8 +239,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             finally:
                 await self.coordinator.async_request_iot_sync()
                 self.coordinator.async_set_updated_data(
-                    self.coordinator.manager.mower(self.coordinator.device_name)
-                )
 
     async def async_pause(self) -> None:
         """Pause mower."""
@@ -271,6 +266,3 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 ) from exc
             finally:
                 await self.coordinator.async_request_iot_sync()
-                self.coordinator.async_set_updated_data(
-                    self.coordinator.manager.mower(self.coordinator.device_name)
-                )

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -104,19 +104,16 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     trans_key = "dock_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                     await self.coordinator.async_request_iot_sync()
-                if work_area > 0 and (
-                    mode == WorkMode.MODE_PAUSE
-                    or mode == WorkMode.MODE_READY
-                    or mode == WorkMode.MODE_RETURNING
-                ):
+                    mode = self.rpt_dev_status.sys_status
+                if mode == WorkMode.MODE_PAUSE :
                     trans_key = "resume_failed"
                     await self.coordinator.async_send_command("resume_execute_task")
                     return await self.coordinator.async_request_iot_sync()
-
-                trans_key = "start_failed"
-                await self.coordinator.async_plan_route()
-                await self.coordinator.async_send_command("start_job")
-                await self.coordinator.async_request_iot_sync()
+                if mode == WorkMode.MODE_READY:
+                    trans_key = "start_failed"
+                    await self.coordinator.async_plan_route()
+                    await self.coordinator.async_send_command("start_job")
+                    await self.coordinator.async_request_iot_sync()
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN, translation_key=trans_key

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -96,32 +96,38 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         if mode is None:
             mode = WorkMode.MODE_READY
         
-        try:
-            if mode == WorkMode.MODE_RETURNING:
-                trans_key = "dock_failed"
-                await self.coordinator.async_send_command("cancel_return_to_dock")
-                await self.coordinator.async_request_iot_sync()
-            if work_area > 0 and (
-                mode == WorkMode.MODE_PAUSE
-                or mode == WorkMode.MODE_READY
-                or mode == WorkMode.MODE_RETURNING
-            ):
-                trans_key = "resume_failed"
-                await self.coordinator.async_send_command("resume_execute_task")
-                return await self.coordinator.async_request_iot_sync()
+        if (
+            mode == WorkMode.MODE_WORKING
+            or mode == WorkMode.MODE_PAUSE
+            or mode == WorkMode.MODE_RETURNING
+        ):
+            try:
+                if mode == WorkMode.MODE_RETURNING:
+                    trans_key = "dock_failed"
+                    await self.coordinator.async_send_command("cancel_return_to_dock")
+                    await self.coordinator.async_request_iot_sync()
+                if work_area > 0 and (
+                    mode == WorkMode.MODE_PAUSE
+                    or mode == WorkMode.MODE_READY
+                    or mode == WorkMode.MODE_RETURNING
+                ):
+                    trans_key = "resume_failed"
+                    await self.coordinator.async_send_command("resume_execute_task")
+                    return await self.coordinator.async_request_iot_sync()
 
-            trans_key = "start_failed"
-            await self.coordinator.async_plan_route()
-            await self.coordinator.async_send_command("start_job")
-            await self.coordinator.async_request_iot_sync()
-        except COMMAND_EXCEPTIONS as exc:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key=trans_key
-            ) from exc
-        finally:
-            self.coordinator.async_set_updated_data(
-                self.coordinator.manager.mower(self.coordinator.device_name)
-            )
+                trans_key = "start_failed"
+                await self.coordinator.async_plan_route()
+                await self.coordinator.async_send_command("start_job")
+                await self.coordinator.async_request_iot_sync()
+            except COMMAND_EXCEPTIONS as exc:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key=trans_key
+                ) from exc
+            finally:
+                self.coordinator.async_set_updated_data(
+                    self.coordinator.manager.mower(self.coordinator.device_name)
+                )
+        return
 
     async def async_dock(self) -> None:
         """Start docking."""
@@ -131,7 +137,14 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         if mode is None:
             mode = WorkMode.MODE_READY
 
-        if charge_state == 0:
+        if (
+            charge_state == 0 
+            and (
+                mode == WorkMode.MODE_WORKING
+                or mode == WorkMode.MODE_PAUSE
+                or mode == WorkMode.MODE_RETURNING
+            )
+        ):
             try:
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_failed"
@@ -155,14 +168,29 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
 
     async def async_pause(self) -> None:
         """Pause mower."""
-        try:
-            await self.coordinator.async_send_command("pause_execute_task")
-            await self.coordinator.async_request_iot_sync()
-        except COMMAND_EXCEPTIONS as exc:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="pause_failed"
-            ) from exc
-        finally:
-            self.coordinator.async_set_updated_data(
-                self.coordinator.manager.mower(self.coordinator.device_name)
-            )
+        
+        mode = self.rpt_dev_status.sys_status
+        if mode is None:
+            mode = WorkMode.MODE_READY
+            
+        if (
+            mode == WorkMode.MODE_WORKING
+            or mode == WorkMode.MODE_RETURNING
+        ):
+            try:
+                if mode == WorkMode.MODE_RETURNING:
+                    trans_key = "dock_failed"
+                    await self.coordinator.async_send_command("cancel_return_to_dock")
+                    return await self.coordinator.async_request_iot_sync()
+                trans_key = "pause_failed"
+                await self.coordinator.async_send_command("pause_execute_task")
+                await self.coordinator.async_request_iot_sync()
+            except COMMAND_EXCEPTIONS as exc:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key=trans_key
+                ) from exc
+            finally:
+                self.coordinator.async_set_updated_data(
+                    self.coordinator.manager.mower(self.coordinator.device_name)
+                )
+        return

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -100,7 +100,8 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
-                    await self.coordinator.async_request_iot_sync() # TODO is this updated on iot sync?
+                    await self.coordinator.async_request_iot_sync()
+                    # TODO is rpt_dev_status updated on iot sync?
                     mode = self.rpt_dev_status.sys_status
 
                 if mode == WorkMode.MODE_PAUSE :

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -92,11 +92,12 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
 
         mode = self.rpt_dev_status.sys_status
         if mode is None:
-            mode = WorkMode.MODE_READY
+            return
         
         if (
             mode == WorkMode.MODE_WORKING
             or mode == WorkMode.MODE_PAUSE
+            or mode == WorkMode.MODE_READY
             or mode == WorkMode.MODE_RETURNING
         ):
             try:
@@ -130,13 +131,14 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         charge_state = self.rpt_dev_status.charge_state
         mode = self.rpt_dev_status.sys_status
         if mode is None:
-            mode = WorkMode.MODE_READY
+            return
 
         if (
             charge_state == 0 
             and (
                 mode == WorkMode.MODE_WORKING
                 or mode == WorkMode.MODE_PAUSE
+                or mode == WorkMode.MODE_READY
                 or mode == WorkMode.MODE_RETURNING
             )
         ):
@@ -166,7 +168,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         
         mode = self.rpt_dev_status.sys_status
         if mode is None:
-            mode = WorkMode.MODE_READY
+            return
             
         if (
             mode == WorkMode.MODE_WORKING

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -104,6 +104,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             if work_area > 0 and (
                 mode == WorkMode.MODE_PAUSE
                 or mode == WorkMode.MODE_READY
+                or mode == WorkMode.MODE_RETURNING
             ):
                 trans_key = "resume_failed"
                 await self.coordinator.async_send_command("resume_execute_task")

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -97,7 +97,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         ):
             try:
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_failed"
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                     await self.coordinator.async_request_iot_sync()
                     # TODO is rpt_dev_status updated on iot sync?
@@ -180,7 +180,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("pause_execute_task")
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_failed"
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -147,7 +147,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     await self.coordinator.async_request_iot_sync()
 
                 if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_failed" # TODO can this be dock_cancel_failed?
+                    trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
                 else:
                     trans_key = "dock_failed"

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -84,15 +84,11 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         """Start mowing."""
         # check if job in progress
         #
-        if self.rpt_dev_status is None:
+        mode = self.rpt_dev_status.sys_status
+        if mode is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="device_not_ready"
             )
-        work_area = self.report_data.work.area >> 16
-
-        mode = self.rpt_dev_status.sys_status
-        if mode is None:
-            return
         
         if (
             mode == WorkMode.MODE_WORKING
@@ -131,7 +127,9 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         charge_state = self.rpt_dev_status.charge_state
         mode = self.rpt_dev_status.sys_status
         if mode is None:
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_not_ready"
+            )
 
         if (
             charge_state == 0 
@@ -168,7 +166,9 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
         
         mode = self.rpt_dev_status.sys_status
         if mode is None:
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_not_ready"
+            )
             
         if (
             mode == WorkMode.MODE_WORKING

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -90,11 +90,10 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 translation_domain=DOMAIN, translation_key="device_not_ready"
             )
         
-        if (
-            mode == WorkMode.MODE_WORKING
-            or mode == WorkMode.MODE_PAUSE
-            or mode == WorkMode.MODE_READY
-            or mode == WorkMode.MODE_RETURNING
+        if mode in (
+            WorkMode.MODE_PAUSE,
+            WorkMode.MODE_READY,
+            WorkMode.MODE_RETURNING,
         ):
             try:
                 if mode == WorkMode.MODE_RETURNING:
@@ -134,11 +133,11 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
 
         if (
             charge_state == 0 
-            and (
-                mode == WorkMode.MODE_WORKING
-                or mode == WorkMode.MODE_PAUSE
-                or mode == WorkMode.MODE_READY
-                or mode == WorkMode.MODE_RETURNING
+            and mode in (
+                WorkMode.MODE_WORKING,
+                WorkMode.MODE_PAUSE,
+                WorkMode.MODE_READY,
+                WorkMode.MODE_RETURNING,
             )
         ):
             try:
@@ -172,9 +171,9 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 translation_domain=DOMAIN, translation_key="device_not_ready"
             )
             
-        if (
-            mode == WorkMode.MODE_WORKING
-            or mode == WorkMode.MODE_RETURNING
+        if mode in (
+            WorkMode.MODE_WORKING,
+            WorkMode.MODE_RETURNING,
         ):
             try:
                 if mode == WorkMode.MODE_WORKING:

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -157,9 +157,6 @@
     "dock_failed": {
       "message": "Failed to send the mower to the dock."
     },
-    "dock_cancel_failed": {
-      "message": "Failed to stop the mower returning."
-    },
     "command_failed": {
       "message": "Failed to send command to the mower."
     }

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -157,6 +157,9 @@
     "dock_failed": {
       "message": "Failed to send the mower to the dock."
     },
+    "dock_cancel_failed": {
+      "message": "Failed to stop the mower returning."
+    },
     "command_failed": {
       "message": "Failed to send command to the mower."
     }

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -249,6 +249,9 @@
     "dock_failed": {
       "message": "Failed to send the mower to the dock."
     },
+    "dock_cancel_failed": {
+      "message": "Failed to stop the mower returning to the dock."
+    },
     "command_failed": {
       "message": "Failed to send command to the mower."
     }

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -346,6 +346,9 @@
     "dock_failed": {
       "message": "Failed to send the mower to the dock."
     },
+    "dock_cancel_failed": {
+      "message": "Failed to stop the mower returning to the dock."
+    },
     "command_failed": {
       "message": "Failed to send command to the mower."
     }


### PR DESCRIPTION
### **User description**
Luba was getting into some weird states when trying to resume while returning. 
Not sure how I did on the exception handling. 

I explicitly checked the mode/status before executing the commands. 
I handled:
 resuming from returning.
 starting from returning.
 pausing from returning. 
 
made sure the "finally" block was run. 
I believe it was possible to miss the finally block in some cases with errors or returns with multiple try blocks. 



Also added "RETURNING" status from Lawnmower to match implementation from HA and i found it disconcerting just seeing "Mowing" as the status while luba returned.


___

### **Description**
- Introduced `RETURNING` state for the lawn mower to improve status reporting.
- Implemented cancellation of return to dock when the mower is starting or resuming from returning.
- Enhanced error handling with specific failure messages for pause and docking operations.
- Limited command execution based on the mower's current work mode to prevent invalid operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lawn_mower.py</strong><dd><code>Enhance LawnMower State Management and Error Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/lawn_mower.py
<li>Added handling for <code>RETURNING</code> mode in mower activity.<br> <li> Cancel return to dock when starting or resuming from returning mode.<br> <li> Improved exception handling with specific translation keys for errors.<br> <li> Limited commands based on mower's work mode.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/135/files#diff-3af9b47c563d00133985b13d37c0fb657cc947de1f4c7feae8bdeb8d849de9d7">+92/-51</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>