### PR TITLE
Add Job Cancellation Service for Lawn Mower

### DIFF
--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -252,18 +252,21 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             WorkMode.MODE_RETURNING,
         ):
             try:
-                if mode != WorkMode.MODE_PAUSE:
-                    if mode == WorkMode.MODE_WORKING:
-                        trans_key = "pause_failed"
-                        await self.coordinator.async_send_command("pause_execute_task")
-                    if mode == WorkMode.MODE_RETURNING:
-                        trans_key = "dock_failed"
-                        await self.coordinator.async_send_command("cancel_return_to_dock")
+                if mode == WorkMode.MODE_WORKING:
+                    trans_key = "pause_failed"
+                    await self.coordinator.async_send_command("pause_execute_task")
                     # TODO is this needed here between commands?
                     await self.coordinator.async_request_iot_sync()
+                if mode == WorkMode.MODE_RETURNING:
+                    trans_key = "dock_failed"
+                    await self.coordinator.async_send_command("cancel_return_to_dock")
+                    # TODO is this needed here between commands?
+                    await self.coordinator.async_request_iot_sync()
+                    mode = self.rpt_dev_status.sys_status
                     
-                trans_key = "pause_failed"
-                await self.coordinator.async_send_command("cancel_job")
+                if mode != WorkMode.MODE_PAUSE:
+                    trans_key = "pause_failed"
+                    await self.coordinator.async_send_command("cancel_job")
 
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -155,6 +155,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     async def async_start_mowing(self, **kwargs: Any) -> None:
         """Start mowing."""
         if kwargs:
+            await self.async_cancel()
             entity_ids = kwargs.get("areas", [])
 
             attributes = [

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -264,7 +264,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     # TODO is this updated by iot_sync? seems to be.
                     mode = self.rpt_dev_status.sys_status
                     
-                if mode != WorkMode.MODE_PAUSE:
+                if mode == WorkMode.MODE_PAUSE:
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("cancel_job")
 

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -272,6 +272,3 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 ) from exc
             finally:
                 await self.coordinator.async_request_iot_sync()
-                self.coordinator.async_set_updated_data(
-                    self.coordinator.manager.mower(self.coordinator.device_name)
-                )

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -252,16 +252,14 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             WorkMode.MODE_RETURNING,
         ):
             try:
-                if mode == WorkMode.MODE_WORKING:
-                    trans_key = "pause_failed"
-                    await self.coordinator.async_send_command("pause_execute_task")
-                    # TODO is this needed here between commands?
+                if mode != WorkMode.MODE_PAUSE:
+                    if mode == WorkMode.MODE_WORKING:
+                        trans_key = "pause_failed"
+                        await self.coordinator.async_send_command("pause_execute_task")
+                    if mode == WorkMode.MODE_RETURNING:
+                        trans_key = "dock_failed"
+                        await self.coordinator.async_send_command("cancel_return_to_dock")
                     await self.coordinator.async_request_iot_sync()
-                if mode == WorkMode.MODE_RETURNING:
-                    trans_key = "dock_failed"
-                    await self.coordinator.async_send_command("cancel_return_to_dock")
-                    await self.coordinator.async_request_iot_sync()
-                    # TODO is this updated by iot_sync? seems to be.
                     mode = self.rpt_dev_status.sys_status
                     
                 if mode == WorkMode.MODE_PAUSE:

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -260,8 +260,8 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
-                    # TODO is this needed here between commands?
                     await self.coordinator.async_request_iot_sync()
+                    # TODO is this updated by iot_sync? seems to be.
                     mode = self.rpt_dev_status.sys_status
                     
                 if mode != WorkMode.MODE_PAUSE:

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -27,6 +27,7 @@ from .coordinator import MammotionDataUpdateCoordinator
 from .entity import MammotionBaseEntity
 
 SERVICE_START_MOWING = "start_mow"
+SERVICE_CANCEL_JOB = "cancel_job"
 
 START_MOW_SCHEMA = {
     vol.Optional("is_mow", default=True): cv.boolean,
@@ -97,6 +98,9 @@ async def async_setup_entry(
         SERVICE_START_MOWING, START_MOW_SCHEMA, "async_start_mowing"
     )
 
+    platform.async_register_entity_service(
+        SERVICE_CANCEL_JOB, None, "async_cancel"
+    )
 
 class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     """Representation of a Mammotion lawn mower."""
@@ -232,3 +236,41 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             self.coordinator.async_set_updated_data(
                 self.coordinator.manager.mower(self.coordinator.device_name)
             )
+
+    async def async_cancel(self) -> None:
+        """Cancel Job"""
+        
+        mode = self.rpt_dev_status.sys_status
+        if mode is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_not_ready"
+            )
+            
+        if mode in (
+            WorkMode.MODE_PAUSE,
+            WorkMode.MODE_WORKING,
+            WorkMode.MODE_RETURNING,
+        ):
+            try:
+                if mode != WorkMode.MODE_PAUSE:
+                    if mode == WorkMode.MODE_WORKING:
+                        trans_key = "pause_failed"
+                        await self.coordinator.async_send_command("pause_execute_task")
+                    if mode == WorkMode.MODE_RETURNING:
+                        trans_key = "dock_failed"
+                        await self.coordinator.async_send_command("cancel_return_to_dock")
+                    # TODO is this needed here between commands?
+                    await self.coordinator.async_request_iot_sync()
+                    
+                trans_key = "pause_failed"
+                await self.coordinator.async_send_command("cancel_job")
+
+            except COMMAND_EXCEPTIONS as exc:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key=trans_key
+                ) from exc
+            finally:
+                await self.coordinator.async_request_iot_sync()
+                self.coordinator.async_set_updated_data(
+                    self.coordinator.manager.mower(self.coordinator.device_name)
+                )

--- a/custom_components/mammotion/services.yaml
+++ b/custom_components/mammotion/services.yaml
@@ -1,3 +1,8 @@
+cancel_job:
+  target:
+    entity:
+      integration: mammotion
+      domain: lawn_mower
 start_mow:
   target:
     entity:

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -144,7 +144,7 @@
   "services": {
     "cancel_job": {
       "name": "Cancel current task",
-      "description": "Stops the mower and clears the current task.",
+      "description": "Stops the mower and clears the current task."
     },
     "start_mow": {
       "name": "Start Mowing",
@@ -235,7 +235,7 @@
           "description": "List of areas to mow (represented as integers)."
         }
       }
-    },
+    }
   },
   "exceptions": {
     "device_not_ready": {

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -142,6 +142,10 @@
     }
   },
   "services": {
+    "cancel_job": {
+      "name": "Cancel current task",
+      "description": "Stops the mower and clears the current task.",
+    },
     "start_mow": {
       "name": "Start Mowing",
       "description": "Start the mowing operation with custom settings.",
@@ -231,7 +235,7 @@
           "description": "List of areas to mow (represented as integers)."
         }
       }
-    }
+    },
   },
   "exceptions": {
     "device_not_ready": {

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -241,7 +241,7 @@
   "services": {
     "cancel_job": {
       "name": "Cancel current task",
-      "description": "Stops the mower and clears the current task.",
+      "description": "Stops the mower and clears the current task."
     },
     "start_mow": {
       "name": "Start Mowing",
@@ -332,7 +332,7 @@
           "description": "List of areas to mow (represented as integers)."
         }
       }
-    },
+    }
   },
   "exceptions": {
     "device_not_ready": {

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -239,6 +239,10 @@
     }
   },
   "services": {
+    "cancel_job": {
+      "name": "Cancel current task",
+      "description": "Stops the mower and clears the current task.",
+    },
     "start_mow": {
       "name": "Start Mowing",
       "description": "Start the mowing operation with custom settings.",
@@ -328,7 +332,7 @@
           "description": "List of areas to mow (represented as integers)."
         }
       }
-    }
+    },
   },
   "exceptions": {
     "device_not_ready": {


### PR DESCRIPTION
### **User description**
Using the buttons from an automation seems to lead to a bad state where luba is canceled but then is returning with a pause condition where it left off but task is restarted. 

Added a service call to access the cancel function in a safer way like the Lawn mower functions for start/resume, pause, return. 

Worked much nicer now to cancel while returning with active task. 
Luba paused, Cancelled, and then Returned using an automation to cancel+Return. 

![Screenshot from 2024-09-20 00-37-47](https://github.com/user-attachments/assets/55975365-b2e9-4925-bea6-22dd606389ba)


___

### **Description**
- Introduced a new service to safely cancel ongoing jobs for the lawn mower.
- Implemented robust error handling to manage various device states during cancellation.
- Enhanced user experience by allowing cancellation while the mower is returning.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lawn_mower.py</strong><dd><code>Implement Job Cancellation Service for Lawn Mower</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/lawn_mower.py
<li>Added a new service call for canceling jobs.<br> <li> Implemented the <code>async_cancel</code> method to handle job cancellation.<br> <li> Enhanced error handling for device states during cancellation.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/140/files#diff-3af9b47c563d00133985b13d37c0fb657cc947de1f4c7feae8bdeb8d849de9d7">+42/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.yaml</strong><dd><code>Add Cancel Job Service Definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/services.yaml
<li>Defined the <code>cancel_job</code> service in the services configuration.<br> <li> Updated service definitions to include the new cancellation <br>functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/140/files#diff-b95a2131e4c28e088c4f7287565ad440b1d018c95bc4d4b2e1c18fee6bc0dd59">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>