### PR TITLE
Cast Area Hashes to Integer for Consistency

### DIFF
--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -153,7 +153,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             entity_ids = kwargs.get("areas", [])
 
             attributes = [
-                get_entity_attribute(self.hass, entity_id, "hash")
+                int(get_entity_attribute(self.hass, entity_id, "hash"))
                 for entity_id in entity_ids
                 if get_entity_attribute(self.hass, entity_id, "hash") is not None
             ]

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -153,6 +153,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
             entity_ids = kwargs.get("areas", [])
 
             attributes = [
+                # TODO this should not need to be cast. 
                 int(get_entity_attribute(self.hass, entity_id, "hash"))
                 for entity_id in entity_ids
                 if get_entity_attribute(self.hass, entity_id, "hash") is not None

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -223,14 +223,14 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
     async def async_turn_on(self, **kwargs: Any) -> None:
         self._attr_is_on = True
         self.entity_description.set_fn(
-            self.coordinator, True, self.entity_description.area
+            self.coordinator, True, int(self.entity_description.area)
         )
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         self._attr_is_on = False
         self.entity_description.set_fn(
-            self.coordinator, False, self.entity_description.area
+            self.coordinator, False, int(self.entity_description.area)
         )
         self.async_write_ha_state()
 

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -216,7 +216,7 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
         self.coordinator = coordinator
         self.entity_description = entity_description
         self._attr_translation_key = entity_description.key
-        self._attr_extra_state_attributes = {"hash": entity_description.area}
+        self._attr_extra_state_attributes = {"hash": int(entity_description.area)}
         # TODO grab defaults from operation_settings
         self._attr_is_on = False  # Default state
 

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -216,6 +216,7 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
         self.coordinator = coordinator
         self.entity_description = entity_description
         self._attr_translation_key = entity_description.key
+        # TODO this should not need to be cast. 
         self._attr_extra_state_attributes = {"hash": int(entity_description.area)}
         # TODO grab defaults from operation_settings
         self._attr_is_on = False  # Default state
@@ -223,6 +224,7 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
     async def async_turn_on(self, **kwargs: Any) -> None:
         self._attr_is_on = True
         self.entity_description.set_fn(
+            # TODO this should not need to be cast. 
             self.coordinator, True, int(self.entity_description.area)
         )
         self.async_write_ha_state()
@@ -230,6 +232,7 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
     async def async_turn_off(self, **kwargs: Any) -> None:
         self._attr_is_on = False
         self.entity_description.set_fn(
+            # TODO this should not need to be cast. 
             self.coordinator, False, int(self.entity_description.area)
         )
         self.async_write_ha_state()


### PR DESCRIPTION
### **User description**
Area hashes seem to be restored as string instead of int from dict on restore after reboot. 

This should not be needed but is a quick fix if it's wanted. 

MammotionConfigAreaSwitchEntityDescription does not seem to be respected on restore.


___

### **Description**
- Cast area hashes to `int` to ensure consistent data types across components.
- This change addresses issues with area hashes being treated as strings.
- Improves the handling of area hashes in both the lawn mower and switch components.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lawn_mower.py</strong><dd><code>Cast Area Hashes to Integer in Lawn Mower Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/lawn_mower.py
<li>Cast area hashes to <code>int</code> during area switch creation.<br> <li> Ensured that <code>None</code> values are handled appropriately.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/147/files#diff-3af9b47c563d00133985b13d37c0fb657cc947de1f4c7feae8bdeb8d849de9d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>switch.py</strong><dd><code>Update Area Hash Handling in Switch Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/switch.py
<li>Cast area hash to <code>int</code> in the switch initialization.<br> <li> Updated state attributes to reflect integer hash values.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/147/files#diff-3481fa1cdf47991315df0bbc9db3a82361d66aab37052fa703409c0514ed184e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>