### PR TITLE
Refactor async_pause for better error handling and execution flow

### DIFF
--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -152,6 +152,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     async def async_start_mowing(self, **kwargs: Any) -> None:
         """Start mowing."""
         trans_key = "pause_failed"
+
         if kwargs:
             await self.async_cancel()
             entity_ids = kwargs.get("areas", [])
@@ -188,7 +189,6 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                     await self.coordinator.async_request_iot_sync()
                     # TODO is rpt_dev_status updated on iot sync?
                     mode = self.rpt_dev_status.sys_status
-
                 if mode == WorkMode.MODE_PAUSE:
                     trans_key = "resume_failed"
                     await self.coordinator.async_send_command("resume_execute_task")
@@ -207,6 +207,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
     async def async_dock(self) -> None:
         """Start docking."""
         trans_key = "pause_failed"
+
         charge_state = self.rpt_dev_status.charge_state
         mode = self.rpt_dev_status.sys_status
         if mode is None:
@@ -240,6 +241,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
 
     async def async_pause(self) -> None:
         """Pause mower."""
+        trans_key = "pause_failed"
 
         mode = self.rpt_dev_status.sys_status
         if mode is None:
@@ -247,30 +249,28 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):
                 translation_domain=DOMAIN, translation_key="device_not_ready"
             )
 
-        try:
-            if mode in (
-                WorkMode.MODE_WORKING,
-                WorkMode.MODE_RETURNING,
-            ):
+        if mode in (
+            WorkMode.MODE_WORKING,
+            WorkMode.MODE_RETURNING,
+        ):
+            try:
                 if mode == WorkMode.MODE_WORKING:
                     trans_key = "pause_failed"
                     await self.coordinator.async_send_command("pause_execute_task")
-                    await self.coordinator.async_request_iot_sync()
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_cancel_failed"
                     await self.coordinator.async_send_command("cancel_return_to_dock")
-        except COMMAND_EXCEPTIONS as exc:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="pause_failed"
-            ) from exc
-        finally:
-            self.coordinator.async_set_updated_data(
-                self.coordinator.manager.mower(self.coordinator.device_name)
-            )
+            except COMMAND_EXCEPTIONS as exc:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key=trans_key
+                ) from exc
+            finally:
+                await self.coordinator.async_request_iot_sync()
 
     async def async_cancel(self) -> None:
         """Cancel Job."""
         trans_key = "pause_failed"
+
         mode = self.rpt_dev_status.sys_status
         if mode is None:
             raise HomeAssistantError(

--- a/custom_components/mammotion/manifest.json
+++ b/custom_components/mammotion/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mammotion",
   "name": "Mammotion",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "issue_tracker": "https://github.com/mikey0000/Mammotion-HA/issues",
   "integration_type": "device",
   "bluetooth": [


### PR DESCRIPTION
### **User description**
touchup lawn_mower.py merge from #135 

I think this was just an issue merging the pause changes and the new cancel function at the same position in the file. 

only real change is moving request_iot_sync to "finally" in async_pause. (also ensuring that it runs after cancelling return)
Then self.coordinator.async_set_updated_data is duplicate behavior of request_iot_sync in finally.


___

### **Description**
- Refactored `async_pause` method to improve error handling and ensure proper execution flow.
- Moved `request_iot_sync` to the `finally` block to guarantee it runs after cancelling return.
- Removed duplicate behavior of `self.coordinator.async_set_updated_data` in `async_pause`.
- Enhanced readability and maintainability of the code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lawn_mower.py</strong><dd><code>Refactor async_pause and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/lawn_mower.py
<li>Moved <code>request_iot_sync</code> to <code>finally</code> block in <code>async_pause</code>.<br> <li> Ensured <code>request_iot_sync</code> runs after cancelling return.<br> <li> Removed duplicate behavior of <code>self.coordinator.async_set_updated_data</code>.<br> <li> Improved error handling in <code>async_pause</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/155/files#diff-3af9b47c563d00133985b13d37c0fb657cc947de1f4c7feae8bdeb8d849de9d7">+15/-15</a>&nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>