### PR TITLE
Enhance de.json with new terms for cancel_job service

### DIFF
--- a/custom_components/mammotion/translations/de.json
+++ b/custom_components/mammotion/translations/de.json
@@ -239,6 +239,10 @@
     }
   },
   "services": {
+    "cancel_job": {
+      "name": "Aktuelle Aufgabe abbrechen",
+      "description": "Stoppt den Mähroboter und bereinigt die aktuelle Aufgabe."
+    },
     "start_mow": {
       "name": "Starte Mähvorgang",
       "description": "Startet einen Mähvorgang mit individuellen Einstellungen.",
@@ -341,6 +345,9 @@
     },
     "dock_failed": {
       "message": "Rückkehr des Mähroboters zur Ladestation fehlgeschlagen."
+    },
+    "dock_cancel_failed": {
+      "message": "Stoppen der Rückkehr des Mähroboters zur Ladestation fehlgeschlagen."
     },
     "command_failed": {
       "message": "Senden eines Befehls zum Mähroboter fehlgeschlagen."


### PR DESCRIPTION
### **Description**
- Introduced new service `cancel_job` with its name and description in German.
- Added error message for failed dock cancellation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>de.json</strong><dd><code>Add new service terms for cancel_job and error messages</code>&nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/translations/de.json
<li>Added new service term for canceling a job.<br> <li> Updated description for the cancel_job service.<br> <li> Introduced a new error message for dock cancellation failure.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/162/files#diff-c28a07b60e03ec21803499d6c521fe20f2952f6a14901a5e279b77f54cc5b500">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>