### PR TITLE
Standardization of Terminology in Translations

### DIFF
--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -287,11 +287,11 @@
         },
         "ultra_wave": {
           "name": "Obstacle Detection",
-          "description": "Bypass strategy for mowing."
+          "description": "Obstacle Avoidance Mode."
         },
         "channel_mode": {
           "name": "Cutting Path Mode",
-          "description": "Path mode (grid, single, double, or single2)."
+          "description": "Cutting Path (zigzag, chessboard, adaptive zigzag, or perimeter only)."
         },
         "channel_width": {
           "name": "Path Width",
@@ -315,7 +315,7 @@
         },
         "toward_mode": {
           "name": "Cutting Angle Mode",
-          "description": "Angle direction of mow."
+          "description": "Anglular direction of mow."
         },
         "border_mode": {
           "name": "Perimeter Mowing Laps",


### PR DESCRIPTION
### **User description**
Just a couple more changes to standardise terms across this integration and the native app


___

### **Description**
- Standardized terminology in the translation file for better clarity and consistency.
- Improved descriptions for various mowing modes to enhance user understanding.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Standardization of Terminology in Translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/translations/en.json
<li>Updated descriptions for various modes to standardize terminology.<br> <li> Changed "Bypass strategy for mowing." to "Obstacle Avoidance Mode."<br> <li> Revised "Path mode (grid, single, double, or single2)." to "Cutting <br>Path (zigzag, chessboard, adaptive zigzag, or perimeter only)."<br> <li> Modified "Angle direction of mow." to "Anglular direction of mow."<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/172/files#diff-0bb36a7037bef8faf3c94b34d207561eefda456e3094f3d0553a2d942445fad3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

