### PR TITLE
Removed country filter from HACS registration

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Mammotion",
-  "country": "NO",
   "homeassistant": "2024.9.0"
 }


### PR DESCRIPTION
### **User description**
Removed country filter from hacs.json defintion

Resolves #187 

___

### **Description**
- Removed the `country` filter from the HACS registration configuration.
- This change simplifies the setup process for users.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hacs.json</strong><dd><code>Update HACS registration configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hacs.json
<li>Removed the <code>country</code> field from the JSON definition.<br> <li> Simplified the configuration for HACS registration.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/188/files#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

