### PR TITLE
Add sensor to diagnostic and some switches and button to configuration

### DIFF
--- a/custom_components/mammotion/binary_sensor.py
+++ b/custom_components/mammotion/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymammotion.data.model.device import MowingDevice
 
@@ -31,6 +32,7 @@ BINARY_SENSORS: tuple[MammotionBinarySensorEntityDescription, ...] = (
         key="charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         is_on_fn=lambda mower_data: mower_data.report_data.dev.charge_state in (1, 2),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 

--- a/custom_components/mammotion/button.py
+++ b/custom_components/mammotion/button.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MammotionConfigEntry
@@ -23,10 +24,12 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
     MammotionButtonSensorEntityDescription(
         key="start_map_sync",
         press_fn=lambda coordinator: coordinator.async_sync_maps(),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="resync_rtk_dock",
         press_fn=lambda coordinator: coordinator.async_rtk_dock_location(),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="release_from_dock",
@@ -35,18 +38,22 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
     MammotionButtonSensorEntityDescription(
         key="emergency_nudge_forward",
         press_fn=lambda coordinator: coordinator.async_move_forward(0.4),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="emergency_nudge_left",
         press_fn=lambda coordinator: coordinator.async_move_left(0.4),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="emergency_nudge_right",
         press_fn=lambda coordinator: coordinator.async_move_right(0.4),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="emergency_nudge_back",
         press_fn=lambda coordinator: coordinator.async_move_back(0.4),
+        entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
         key="cancel_task",
@@ -55,6 +62,7 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
     MammotionButtonSensorEntityDescription(
         key="clear_all_mapdata",
         press_fn=lambda coordinator: coordinator.clear_all_maps(),
+        entity_category=EntityCategory.CONFIG,
     ),
 )
 

--- a/custom_components/mammotion/sensor.py
+++ b/custom_components/mammotion/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.unit_conversion import SpeedConverter
@@ -51,6 +52,7 @@ LUBA_SENSOR_ONLY_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         value_fn=lambda mower_data: mower_data.report_data.work.knife_height,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 
@@ -62,6 +64,7 @@ LUBA_2_YUKA_ONLY_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         value_fn=lambda mower_data: camera_brightness(
             mower_data.report_data.vision_info.brightness
         ),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="maintenance_distance",
@@ -69,12 +72,14 @@ LUBA_2_YUKA_ONLY_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
         value_fn=lambda mower_data: mower_data.report_data.maintenance.mileage,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="maintenance_bat_cycles",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: mower_data.report_data.maintenance.bat_cycles,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="maintenance_work_time",
@@ -82,6 +87,7 @@ LUBA_2_YUKA_ONLY_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda mower_data: mower_data.report_data.maintenance.work_time,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 
@@ -92,6 +98,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda mower_data: mower_data.report_data.dev.battery_val,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="ble_rssi",
@@ -99,6 +106,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         value_fn=lambda mower_data: mower_data.report_data.connect.ble_rssi,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="wifi_rssi",
@@ -106,12 +114,14 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         value_fn=lambda mower_data: mower_data.report_data.connect.wifi_rssi,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="connect_type",
         device_class=SensorDeviceClass.ENUM,
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: device_connection(mower_data.report_data.connect),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="gps_stars",
@@ -119,6 +129,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=None,
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: mower_data.report_data.rtk.gps_stars,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="area",
@@ -126,6 +137,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=None,
         native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         value_fn=lambda mower_data: mower_data.report_data.work.area & 65535,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="mowing_speed",
@@ -133,6 +145,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         value_fn=lambda mower_data: mower_data.report_data.work.man_run_speed / 100,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="progress",
@@ -140,6 +153,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=None,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda mower_data: mower_data.report_data.work.area >> 16,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="total_time",
@@ -147,6 +161,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: mower_data.report_data.work.progress & 65535,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="elapsed_time",
@@ -155,6 +170,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: (mower_data.report_data.work.progress & 65535)
         - (mower_data.report_data.work.progress >> 16),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="left_time",
@@ -162,6 +178,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda mower_data: mower_data.report_data.work.progress >> 16,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="l1_satellites",
@@ -170,6 +187,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: (mower_data.report_data.rtk.co_view_stars >> 0)
         & 255,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="l2_satellites",
@@ -178,6 +196,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: (mower_data.report_data.rtk.co_view_stars >> 8)
         & 255,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # MammotionSensorEntityDescription(
     #     key="vlsam_status",
@@ -191,6 +210,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         state_class=None,
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda mower_data: device_mode(mower_data.report_data.dev.sys_status),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="position_mode",
@@ -200,6 +220,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         value_fn=lambda mower_data: str(
             RTKStatus.from_value(mower_data.report_data.rtk.status)
         ),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="position_type",
@@ -209,6 +230,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         value_fn=lambda mower_data: str(
             PosType(mower_data.location.position_type).name
         ),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionSensorEntityDescription(
         key="work_area",
@@ -216,6 +238,7 @@ SENSOR_TYPES: tuple[MammotionSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         native_unit_of_measurement=None,
         value_fn=lambda mower_data: str(mower_data.location.work_zone or "Not working"),
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # MammotionSensorEntityDescription(
     #     key="lawn_mower_position",

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -220,6 +220,7 @@ class MammotionSwitchEntity(MammotionBaseEntity, SwitchEntity):
 class MammotionUpdateSwitchEntity(MammotionBaseEntity, SwitchEntity, RestoreEntity):
     entity_description: MammotionUpdateSwitchEntityDescription
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,


### PR DESCRIPTION
## Changes

Move some entities to diagnostic and sensor to be have it exposed by default in voice assistants and not having it display on the default dashboard.

I have a question for `Blade on/off` and `Side LED on/off`. I think it should be a configuration because it's a setting but I'm not sure. WDYT @mikey0000?

## Before

![CleanShot 2025-03-20 at 12 07 27](https://github.com/user-attachments/assets/6791cf21-b316-4dc9-b55f-e7093531e26b)

## After 

![CleanShot 2025-03-20 at 12 00 48](https://github.com/user-attachments/assets/58256c3f-9a34-4f6b-8f85-90f0527fbd0f)
