### PR TITLE
Fix missing content_type in WebRTC and improve device data fetching

### DIFF
--- a/custom_components/mammotion/camera.py
+++ b/custom_components/mammotion/camera.py
@@ -105,8 +105,7 @@ class MammotionWebRTCCamera(MammotionBaseEntity, Camera):
         self._legacy_webrtc_provider = None
         self._supports_native_sync_webrtc = False
         self._supports_native_async_webrtc = False
-        # Use config option with fallback to default value
-        self.content_type = coordinator.config_entry.options.get("content_type", "image/jpeg")
+        self.content_type = "image/jpeg"  # Add required attribute for MJPEG streaming
 
     @property
     def frontend_stream_type(self) -> StreamType | None:

--- a/custom_components/mammotion/camera.py
+++ b/custom_components/mammotion/camera.py
@@ -105,7 +105,8 @@ class MammotionWebRTCCamera(MammotionBaseEntity, Camera):
         self._legacy_webrtc_provider = None
         self._supports_native_sync_webrtc = False
         self._supports_native_async_webrtc = False
-        self.content_type = "image/jpeg"  # Add required attribute for MJPEG streaming
+        # Use config option with fallback to default value
+        self.content_type = coordinator.config_entry.options.get("content_type", "image/jpeg")
 
     @property
     def frontend_stream_type(self) -> StreamType | None:

--- a/custom_components/mammotion/camera.py
+++ b/custom_components/mammotion/camera.py
@@ -105,6 +105,7 @@ class MammotionWebRTCCamera(MammotionBaseEntity, Camera):
         self._legacy_webrtc_provider = None
         self._supports_native_sync_webrtc = False
         self._supports_native_async_webrtc = False
+        self.content_type = "image/jpeg"  # Add required attribute for MJPEG streaming
 
     @property
     def frontend_stream_type(self) -> StreamType | None:

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -304,16 +304,8 @@ class MammotionBaseUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
 
     async def async_blade_height(self, height: int) -> int:
         """Set blade height."""
-        # Check if device is online before sending command
-        if self.device_is_online():
-            await self.async_send_command("set_blade_height", height=height)
+        await self.async_send_command("set_blade_height", height=height)
         return height
-        
-    def device_is_online(self) -> bool:
-        """Check if the device is online before sending commands."""
-        if hasattr(self, 'data') and self.data is not None:
-            return getattr(self.data, 'online', False)
-        return False
 
     async def async_leave_dock(self) -> None:
         """Leave dock."""

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -303,8 +303,16 @@ class MammotionBaseUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
 
     async def async_blade_height(self, height: int) -> int:
         """Set blade height."""
-        await self.async_send_command("set_blade_height", height=height)
+        # Check if device is online before sending command
+        if self.device_is_online():
+            await self.async_send_command("set_blade_height", height=height)
         return height
+        
+    def device_is_online(self) -> bool:
+        """Check if the device is online before sending commands."""
+        if hasattr(self, 'data') and self.data is not None:
+            return getattr(self.data, 'online', False)
+        return False
 
     async def async_leave_dock(self) -> None:
         """Leave dock."""

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -528,7 +528,15 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         device = self.manager.get_device_by_name(self.device_name)
 
         try:
+            # Ensure we get the most up-to-date configuration from the device
             await self.async_send_command("get_report_cfg")
+            
+            # Get blade height and other working parameters
+            if not DeviceType.is_luba1(self.device_name):
+                try:
+                    await self.async_send_command("get_blade_height")
+                except Exception as e:
+                    LOGGER.debug("Failed to get blade height: %s", e)
 
         except DeviceOfflineException as ex:
             """Device is offline try bluetooth if we have it."""

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -96,7 +95,6 @@ LUBA_WORKING_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
             coordinator.operation_settings, "blade_height", int(value)
         ),
         get_fn=lambda coordinator: coordinator.data.report_data.work.knife_height,
-        update_fn=lambda coordinator, value: coordinator.async_blade_height(int(value)),
     ),
 )
 
@@ -199,10 +197,8 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):
         self.entity_description.set_fn(self.coordinator, value)
         
         if self.entity_description.update_fn is not None:
-            # Always store the result in case it's a coroutine
             result = self.entity_description.update_fn(self.coordinator, value)
-            # Check if it's awaitable
-            if asyncio.iscoroutine(result):
+            if result is not None and hasattr(result, "__await__"):
                 await result
         # If this is blade height and no update_fn is defined, directly set it on the device
         elif self.entity_description.key == "blade_height":

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -196,8 +197,10 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):
         self.entity_description.set_fn(self.coordinator, value)
         
         if self.entity_description.update_fn is not None:
+            # Always store the result in case it's a coroutine
             result = self.entity_description.update_fn(self.coordinator, value)
-            if result is not None and hasattr(result, "__await__"):
+            # Check if it's awaitable
+            if asyncio.iscoroutine(result):
                 await result
         # If this is blade height and no update_fn is defined, directly set it on the device
         elif self.entity_description.key == "blade_height":

--- a/custom_components/mammotion/select.py
+++ b/custom_components/mammotion/select.py
@@ -1,9 +1,6 @@
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Awaitable
-
-_LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
@@ -253,8 +250,8 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
                     option = self.entity_description.value_map[value]
                     if option in self.entity_description.options:
                         self._attr_current_option = option
-            except Exception as e:
-                _LOGGER.debug("Error retrieving value from device: %s", e)
+            except (AttributeError, KeyError, TypeError):
+                pass
 
     @property
     def current_option(self) -> str:
@@ -317,8 +314,8 @@ class MammotionAsyncConfigSelectEntity(
                     option = self.entity_description.value_map[value]
                     if option in self.entity_description.options:
                         self._attr_current_option = option
-            except Exception as e:
-                _LOGGER.debug("Error retrieving value from device: %s", e)
+            except (AttributeError, KeyError, TypeError):
+                pass
 
     @property
     def current_option(self) -> str:

--- a/custom_components/mammotion/select.py
+++ b/custom_components/mammotion/select.py
@@ -1,6 +1,9 @@
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Awaitable
+
+_LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
@@ -250,8 +253,8 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
                     option = self.entity_description.value_map[value]
                     if option in self.entity_description.options:
                         self._attr_current_option = option
-            except (AttributeError, KeyError, TypeError):
-                pass
+            except Exception as e:
+                _LOGGER.debug("Error retrieving value from device: %s", e)
 
     @property
     def current_option(self) -> str:
@@ -314,8 +317,8 @@ class MammotionAsyncConfigSelectEntity(
                     option = self.entity_description.value_map[value]
                     if option in self.entity_description.options:
                         self._attr_current_option = option
-            except (AttributeError, KeyError, TypeError):
-                pass
+            except Exception as e:
+                _LOGGER.debug("Error retrieving value from device: %s", e)
 
     @property
     def current_option(self) -> str:


### PR DESCRIPTION
### **User description**
Fixes camera preview by adding missing content_type attribute to MammotionWebRTCCamera. Enhances configuration panel to display actual device values instead of defaults for blade height, mow order, etc.


___

### **Description**
- Added `content_type` attribute for MJPEG streaming in the camera component.
- Implemented async updates for blade height and other parameters from device data.
- Enhanced error handling for fetching blade height.
- Updated number entity to refresh UI with actual values.
- Improved select entity descriptions to dynamically fetch current options from device data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>camera.py</strong><dd><code>Add content type for MJPEG streaming in camera</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/camera.py
<li>Added <code>content_type</code> attribute for MJPEG streaming in the camera <br>component.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/316/files#diff-077e4162e67170d3d23c28f2f6461a4c8b4a18e49717b1d667de6056e84d7c22">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Improve async data fetching and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/coordinator.py
<li>Implemented async updates for blade height and other parameters from <br>device data.<br> <li> Enhanced error handling for fetching blade height.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/316/files#diff-f8a4a06ede7f30cde21a849be8db19504f7080576f20551e2d0a9c5a7d1d2756">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>number.py</strong><dd><code>Enhance number entity value setting functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/number.py
<li>Updated <code>async_set_native_value</code> to call <code>update_fn</code> if defined.<br> <li> Added logic to refresh UI with actual blade height value.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/316/files#diff-719f171f63011c92986f644dbe17d4ff3b1bd16ddf561a91072e54029ea855d9">+23/-19</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>select.py</strong><dd><code>Improve select entity with dynamic option updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/select.py
<li>Added <code>get_fn</code> and <code>value_map</code> to select entity descriptions for dynamic <br>updates.<br> <li> Implemented logic to update current option from device data.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/316/files#diff-1fcdc3a5572297510447ff56ad231dcf12f3cdefc040c06ad12e97527545d05c">+83/-2</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

