### PR TITLE
Add 'autostart' parameters

### DIFF
--- a/custom_components/mammotion/www/agora-client.js
+++ b/custom_components/mammotion/www/agora-client.js
@@ -21,7 +21,12 @@ class CameraAgoraCard extends HTMLElement {
     if (!config.entity) {
       throw new Error("You need to specify an entity");
     }
-    this._config = config;
+
+    //Define custom parameters
+    this._config = {
+      ...config,
+      autostart: config.autostart !== undefined ? config.autostart : false
+    };
     
     // Prepare shadow DOM container
     this.attachShadow({ mode: 'open' });
@@ -173,8 +178,14 @@ class CameraAgoraCard extends HTMLElement {
         return;
       }
       
-      // Start playback immediately
-      this._playVideo();
+      if(this._config.autostart)
+      {
+        // Start playback immediately
+        this._playVideo();
+      }
+      else
+        this._showLoading("Press play to start video stream");
+      
     } catch (error) {
       console.error("Error initializing Agora:", error);
       this._showError(`Error: ${error.message}`);


### PR DESCRIPTION
### **User description**
Add 'autostart' parameters for automatic stream start on page load


___

### **Description**
- Introduced `autostart` parameter for automatic video stream start on page load.
- Enhanced playback logic to conditionally start video based on the `autostart` setting.
- Improved user feedback by displaying a loading message when not autostarting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agora-client.js</strong><dd><code>Implement 'autostart' Parameter for Video Playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/mammotion/www/agora-client.js
<li>Added <code>autostart</code> parameter to the configuration.<br> <li> Modified video playback logic to start automatically based on <br><code>autostart</code>.<br> <li> Updated error handling to show loading message when not autostarting.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/Mammotion-HA/pull/325/files#diff-a7569a1b2af96070285e8d71e3b1f60e960a010ee3645b5fea3031e0ff4b22bd">+14/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

