### PR TITLE
Fix typo in sv.json

### DIFF
--- a/custom_components/mammotion/translations/sv.json
+++ b/custom_components/mammotion/translations/sv.json
@@ -166,7 +166,7 @@
     },
     "switch": {
       "area": {
-        "name": "Område {namn}"
+        "name": "Område {name}"
       },
       "blade_status": {
         "name": "Blad på/av"


### PR DESCRIPTION
Fix Validation of translation placeholders for localized (sv) string component.mammotion.entity.switch.area.name failed: ({'namn'} != {'name'})