### PR TITLE
Fix TypeError: cloud.stop() is not awaitable in async_setup_entry

### DIFF
--- a/custom_components/mammotion/__init__.py
+++ b/custom_components/mammotion/__init__.py
@@ -221,8 +221,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
 
             if not use_wifi:
                 mammotion_device.preference = ConnectionPreference.BLUETOOTH
-                await mammotion_device.cloud.stop()
-                mammotion_device.cloud.mqtt.disconnect() if mammotion_device.cloud.mqtt.is_connected() else None
+                if mammotion_device.cloud:
+                    mammotion_device.cloud.stop()
+                    mammotion_device.cloud.mqtt.disconnect() if mammotion_device.cloud.mqtt.is_connected() else None
                 # not entirely sure this is a good idea
                 mammotion_device.remove_cloud()
 


### PR DESCRIPTION
## Bug

`async_setup_entry` in `__init__.py` line 223 crashes with:

```
TypeError: 'NoneType' object can't be awaited
```

Full traceback:
```
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 769, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/mammotion/__init__.py", line 223, in async_setup_entry
    await mammotion_device.cloud.stop()
TypeError: 'NoneType' object can't be awaited
```

## Cause

`cloud.stop()` is a synchronous method (returns `None`), but it was being called with `await`. The coordinator at line 232 already calls it correctly without `await`.

Additionally, `mammotion_device.cloud` can be `None` at this point.

## Fix

- Removed `await` from `cloud.stop()` to match existing usage in `coordinator.py`
- Added a `None` guard on `mammotion_device.cloud` to prevent `AttributeError`

## Version

v0.4.44
