### PR TITLE
fix(translations): correct toward_mode / cutting_angle_mode labels in en.json

### DIFF
--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -326,8 +326,8 @@
       "cutting_angle_mode": {
         "name": "Cutting path angle mode",
         "state": {
-          "relative_angle": "Optimal angle",
-          "absolute_angle": "North angle",
+          "relative_angle": "Relative angle",
+          "absolute_angle": "Absolute angle",
           "random_angle": "Random angle"
         }
       },
@@ -416,8 +416,8 @@
     },
     "toward_mode": {
       "options": {
-        "0": "Optimal angle",
-        "1": "North angle",
+        "0": "Relative angle",
+        "1": "Absolute angle",
         "2": "Random angle"
       }
     },


### PR DESCRIPTION
## Summary

The English translation for `toward_mode` (service `start_mow`) and `cutting_angle_mode` (select entity) does not match the underlying `PathAngleSetting` enum in PyMammotion. This PR aligns the English labels with the German translation, which is already correct, and with the canonical enum names.

See #585 for the full bug analysis. In short:

- `relative_angle` (0) was labeled "Optimal angle" — should be "Relative angle"
- `absolute_angle` (1) was labeled "North angle" — should be "Absolute angle"
- `random_angle` (2) is correct.

This is a pure translation fix. No code changes, no behavior changes — only the user-facing labels become accurate, so users picking a value from the dropdown actually get what the label says.

## Diff

`custom_components/mammotion/translations/en.json`:

```diff
       "cutting_angle_mode": {
         "name": "Cutting path angle mode",
         "state": {
-          "relative_angle": "Optimal angle",
-          "absolute_angle": "North angle",
+          "relative_angle": "Relative angle",
+          "absolute_angle": "Absolute angle",
           "random_angle": "Random angle"
         }
       },
```

```diff
     "toward_mode": {
       "options": {
-        "0": "Optimal angle",
-        "1": "North angle",
+        "0": "Relative angle",
+        "1": "Absolute angle",
         "2": "Random angle"
       }
     },
```

## Test plan

- [ ] Verified `de.json` already uses the correct German equivalents (Relativer / Absoluter / Zufälliger Winkel)
- [ ] Verified `PyMammotion` enum names match: `relative_angle=0, absolute_angle=1, random_angle=2`
- [ ] No code paths reference the human-readable labels; only enum names / int values are used internally

## Closes

Closes #585