### PR TITLE
feat: add app_interactive binary sensor

### DIFF
--- a/custom_components/mammotion/binary_sensor.py
+++ b/custom_components/mammotion/binary_sensor.py
@@ -34,6 +34,12 @@ BINARY_SENSORS: tuple[MammotionBinarySensorEntityDescription, ...] = (
         is_on_fn=lambda mower_data: mower_data.report_data.dev.charge_state in (1, 2),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    MammotionBinarySensorEntityDescription(
+        key="app_interactive",
+        translation_key="app_interactive",
+        is_on_fn=lambda mower_data: mower_data.report_data.connect.connect_type == 3,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -207,6 +207,11 @@
         }
       }
     },
+    "binary_sensor": {
+      "app_interactive": {
+        "name": "App interactive"
+      }
+    },
     "button": {
       "start_map_sync": {
         "name": "Sync maps"

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -280,6 +280,11 @@
         }
       }
     },
+    "binary_sensor": {
+      "app_interactive": {
+        "name": "App interactive"
+      }
+    },
     "button": {
       "start_map_sync": {
         "name": "Sync maps"


### PR DESCRIPTION
## Summary

Adds `binary_sensor.{device}_app_interactive` — `on` whenever `report_data.connect.connect_type == 3`.

## Context

`connect_type == 3` is the previously-unnamed value that fires only when the Mammotion app is in an active interactive screen (manual drive, live view) — see https://github.com/mikey0000/PyMammotion/pull/156 for the trace evidence and enum addition.

The motivating use case is gating automations that should suppress alerts during direct user interaction. Example: a "robot stranded" automation that watches for off-dock-idle conditions will false-fire while the user is manually driving the mower around the yard (lawn_mower state is `paused` between joystick commands, battery is non-full, position is non-CHARGE_ON — every signal except this one looks like a stranding). Adding the binary_sensor lets that automation add a simple `binary_sensor.robie_app_interactive == off` condition.

Exposed as `EntityCategory.DIAGNOSTIC` since it's not something a user would drive directly — its value is purely for automations / debugging.

## Test plan

- [ ] Entity appears as `binary_sensor.{device}_app_interactive` with friendly name "App interactive"
- [ ] State flips `on` when opening the Mammotion app's manual-drive / live-view screen
- [ ] State returns to `off` after closing the screen
- [ ] Verified live on Yuka Mini 2
