### PR TITLE
Don't reload the config entry on Bluetooth discovery (keeps the live cloud session alive)

### DIFF
--- a/custom_components/mammotion/config_flow.py
+++ b/custom_components/mammotion/config_flow.py
@@ -80,10 +80,6 @@ class MammotionConfigFlow(ConfigFlow, domain=DOMAIN):
                             device_entry.id,
                             merge_connections={(CONNECTION_BLUETOOTH, formatted_ble)},
                         )
-                        if entry.state == config_entries.ConfigEntryState.LOADED:
-                            self.hass.config_entries.async_schedule_reload(
-                                entry.entry_id
-                            )
                     return entry
         return None
 


### PR DESCRIPTION
## Problem

On a Wi-Fi / cloud setup where the mower advertises over BLE but is out of connectable range, the config entry gets reloaded ~once per startup, tearing down the live cloud (Mammotion MQTT) subscription. After that, state only refreshes at the slow `mqtt_activity_loop` poll cadence (20–60 min), so sensors / `lawn_mower` / position freeze — the same "stale until I open the Mammotion app" symptom several users have described.

## Root cause

The Bluetooth-discovery matcher in `config_flow.py` calls `async_schedule_reload(entry.entry_id)` the first time it records a device's BLE address as a device-registry connection:

```python
if not already_connected:
    device_registry.async_update_device(
        device_entry.id,
        merge_connections={(CONNECTION_BLUETOOTH, formatted_ble)},
    )
    if entry.state == config_entries.ConfigEntryState.LOADED:
        self.hass.config_entries.async_schedule_reload(entry.entry_id)   # <-- here
```

HA replays the BLE advertisement on every start. For a cloud-connected mower that only advertises (RSSI too low to actually connect), `already_connected` is false, so this reloads the loaded entry, and the reload runs `handle.stop()` → `transport.disconnect()`, killing the cloud MQTT session that was streaming `toappReportData`.

## Fix

Drop the reload. The device-registry connection merge is kept (useful for the UI). Runtime BLE attachment is already handled by the `_ble_seen` bluetooth callback (`__init__.py` → `add_ble_to_device`), so the reload is redundant.

## Validation

Reproduced on a Yuka Mini 2 1000 (EU cloud, BLE out of range), integration v0.6.1 / pymammotion 0.7.131, HA Core 2026.5.4. A stack trace injected on `MQTTTransport.disconnect()` confirmed the chain `config_entries.async_reload → async_unload → handle.stop() → transport.disconnect()` firing ~35 s after every boot.

With this change: **0 reloads**, the cloud MQTT stays connected, and `toappReportData` streams continuously (verified stable for several minutes, well past the previous ~35 s drop).

## Related (not claiming to close)

This was reproduced and fixed only for the cloud / BLE-out-of-range case above. It may be the same root cause behind the "stale until the app is opened" reports in #698, #654, #732 and #751, but I haven't reproduced each of those setups — referencing them rather than asserting a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
