### PR TITLE
mammotion: tidy up yuka 2 controls

### DIFF
--- a/custom_components/mammotion/__init__.py
+++ b/custom_components/mammotion/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from datetime import datetime
-from typing import Any
+from datetime import UTC, datetime, timedelta
+from typing import Any, Mapping
 
 from aiohttp import ClientConnectorError
 from homeassistant.components import bluetooth
@@ -99,6 +99,52 @@ PLATFORMS: list[Platform] = [
 
 type MammotionConfigEntry = ConfigEntry[MammotionDevices]
 
+_CLOUD_AUTH_BACKOFF = timedelta(hours=12)
+_CLOUD_AUTH_BACKOFF_UNTIL = "cloud_auth_backoff_until"
+
+
+def _cloud_auth_backoff_until(data: Mapping[str, Any]) -> datetime | None:
+    raw_deadline = data.get(_CLOUD_AUTH_BACKOFF_UNTIL)
+    if not isinstance(raw_deadline, str):
+        return None
+    try:
+        deadline = datetime.fromisoformat(raw_deadline)
+    except ValueError:
+        return None
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=UTC)
+    return deadline
+
+
+def _cloud_auth_backoff_active(data: Mapping[str, Any]) -> bool:
+    deadline = _cloud_auth_backoff_until(data)
+    return deadline is not None and deadline > datetime.now(UTC)
+
+
+def _with_cloud_auth_backoff(data: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        **data,
+        _CLOUD_AUTH_BACKOFF_UNTIL: (
+            datetime.now(UTC) + _CLOUD_AUTH_BACKOFF
+        ).isoformat(),
+    }
+
+
+def _without_cloud_auth_backoff(data: Mapping[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in data.items() if k != _CLOUD_AUTH_BACKOFF_UNTIL}
+
+
+def _start_cloud_auth_backoff(
+    hass: HomeAssistant,
+    entry: MammotionConfigEntry,
+) -> None:
+    if _cloud_auth_backoff_active(entry.data):
+        return
+    hass.config_entries.async_update_entry(
+        entry,
+        data=_with_cloud_auth_backoff(entry.data),
+    )
+
 
 def _has_ble_devices(entry: MammotionConfigEntry) -> bool:
     """Return True if the entry has at least one BLE device address."""
@@ -135,11 +181,11 @@ async def _async_attempt_login(
     except LoginFailedError as err:
         if ble_fallback:
             LOGGER.warning(
-                "Mammotion login failed; continuing in BLE-only mode: %s", err
+                "Mammotion cloud login failed; keeping cloud account configured "
+                "and continuing with Bluetooth fallback: %s",
+                err,
             )
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, CONF_HAS_CLOUD_ACCOUNT: False}
-            )
+            _start_cloud_auth_backoff(hass, entry)
             return False
         raise ConfigEntryAuthFailed(err) from err
     except EXPIRED_CREDENTIAL_EXCEPTIONS as exc:
@@ -158,10 +204,23 @@ async def _async_attempt_login(
                 CONF_CONNECT_DATA,
                 CONF_MAMMOTION_DATA,
             )
+            data_without_stale_credentials = {
+                k: v for k, v in entry.data.items() if k not in stale_keys
+            }
             hass.config_entries.async_update_entry(
                 entry,
-                data={k: v for k, v in entry.data.items() if k not in stale_keys},
+                data=data_without_stale_credentials,
             )
+            if ble_fallback:
+                LOGGER.warning(
+                    "Mammotion cached cloud credentials expired; continuing with "
+                    "Bluetooth fallback and backing off cloud login"
+                )
+                hass.config_entries.async_update_entry(
+                    entry,
+                    data=_with_cloud_auth_backoff(data_without_stale_credentials),
+                )
+                return False
         try:
             await mammotion.login_and_initiate_cloud(
                 account, password, aiohttp_client.async_get_clientsession(hass)
@@ -170,12 +229,12 @@ async def _async_attempt_login(
         except (LoginFailedError, ReLoginRequiredError) as retry_err:
             if ble_fallback:
                 LOGGER.warning(
-                    "Login failed after cache clear; continuing in BLE-only mode: %s",
+                    "Mammotion cloud login failed after cache clear; keeping "
+                    "cloud account configured and continuing with Bluetooth "
+                    "fallback: %s",
                     retry_err,
                 )
-                hass.config_entries.async_update_entry(
-                    entry, data={**entry.data, CONF_HAS_CLOUD_ACCOUNT: False}
-                )
+                _start_cloud_auth_backoff(hass, entry)
                 return False
             raise ConfigEntryAuthFailed(retry_err) from retry_err
     except AccountInUseError as err:
@@ -184,13 +243,18 @@ async def _async_attempt_login(
                 "Mammotion account in use elsewhere; continuing in BLE-only mode: %s",
                 err,
             )
+            _start_cloud_auth_backoff(hass, entry)
             return False
         raise ConfigEntryError(
             translation_domain=DOMAIN, translation_key="account_in_use"
         ) from err
     except TooManyRequestsException as err:
         if ble_fallback:
-            LOGGER.warning("Mammotion API rate limited; continuing in BLE-only mode")
+            LOGGER.warning(
+                "Mammotion API rate limited; continuing with Bluetooth fallback "
+                "and backing off cloud login"
+            )
+            _start_cloud_auth_backoff(hass, entry)
             return False
         raise ConfigEntryError(
             translation_domain=DOMAIN, translation_key="api_limit_exceeded"
@@ -200,6 +264,7 @@ async def _async_attempt_login(
             LOGGER.warning(
                 "Unretryable login error; continuing in BLE-only mode: %s", err
             )
+            _start_cloud_auth_backoff(hass, entry)
             return False
         raise ConfigEntryError(err)
     except Exception:
@@ -317,7 +382,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
     mammotion = MammotionClient(ha_version=integration.version.split("-")[0])
     account = entry.data.get(CONF_ACCOUNTNAME)
     password = entry.data.get(CONF_PASSWORD)
-    use_wifi = entry.data.get(CONF_USE_WIFI, True)
 
     # Migrate options: move from stay_connected_bluetooth to prefer_ble default.
     if not entry.options:
@@ -340,6 +404,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
     has_cloud_account = entry.data.get(
         CONF_HAS_CLOUD_ACCOUNT, bool(account and password)
     )
+    if has_cloud_account and entry.data.get(CONF_USE_WIFI) is not True:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_USE_WIFI: True},
+        )
 
     # Wire credential-save callback before login so any re-login triggered
     # during transport bind setup (e.g. _on_aliyun_auth_failure) is captured.
@@ -362,7 +431,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
 
     cloud_available = False
 
-    if has_cloud_account and account and password:
+    if has_cloud_account and account and password and _cloud_auth_backoff_active(
+        entry.data
+    ):
+        deadline = _cloud_auth_backoff_until(entry.data)
+        LOGGER.warning(
+            "Mammotion cloud auth is backed off until %s; using Bluetooth "
+            "fallback without another cloud login attempt",
+            deadline.isoformat() if deadline is not None else "unknown",
+        )
+    elif has_cloud_account and account and password:
         cloud_available = await _async_attempt_login(
             hass,
             entry,
@@ -384,6 +462,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
             raise ConfigEntryAuthFailed()
 
         mammotion.on_unrecoverable_auth_error = _on_unrecoverable_auth_error
+        if _cloud_auth_backoff_until(entry.data) is not None:
+            hass.config_entries.async_update_entry(
+                entry,
+                data=_without_cloud_auth_backoff(entry.data),
+            )
         store_cloud_credentials(hass, entry, mammotion)
 
         mower_devices, mammotion_rtk_devices, spino_devices = _build_device_list(
@@ -400,16 +483,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
                     device_ble_address,
                 )
 
-            if not use_wifi:
-                mammotion.set_prefer_ble(device.device_name, prefer_ble=True)
-                handle = mammotion.mower(device.device_name)
-                if handle is not None:
-                    for t_type in (
-                        TransportType.CLOUD_ALIYUN,
-                        TransportType.CLOUD_MAMMOTION,
-                    ):
-                        await handle.disconnect_transport(t_type)
-            elif prefer_ble:
+            if prefer_ble:
                 mammotion.set_prefer_ble(device.device_name, prefer_ble=True)
 
             mammotion.set_mow_path_fetch_enabled(
@@ -437,7 +511,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
             await _await_device_connection(
                 mammotion,
                 device.device_name,
-                prefer_ble=(not use_wifi or prefer_ble),
+                prefer_ble=prefer_ble,
             )
 
             await report_coordinator.async_restore_data()

--- a/custom_components/mammotion/__init__.py
+++ b/custom_components/mammotion/__init__.py
@@ -92,6 +92,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.IMAGE,
     Platform.CAMERA,
     Platform.UPDATE,
     Platform.VACUUM,

--- a/custom_components/mammotion/config_flow.py
+++ b/custom_components/mammotion/config_flow.py
@@ -341,7 +341,7 @@ class MammotionConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_ACCOUNTNAME: account or None,
                         CONF_PASSWORD: password or None,
                         CONF_ACCOUNT_ID: account_id,
-                        CONF_USE_WIFI: bool(account),
+                        CONF_USE_WIFI: bool(has_cloud_account),
                         CONF_HAS_CLOUD_ACCOUNT: has_cloud_account,
                     },
                     reason="reconfigure_successful",

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import datetime
 import json
+import math
 import secrets
 import time
 from abc import abstractmethod
@@ -95,6 +96,7 @@ from .const import (
     LOGGER,
     NO_REQUEST_MODES,
 )
+from .yuka import is_yuka_2
 
 if TYPE_CHECKING:
     from . import MammotionConfigEntry
@@ -102,10 +104,32 @@ if TYPE_CHECKING:
 MAINTENANCE_INTERVAL = timedelta(minutes=60)
 DEFAULT_INTERVAL = timedelta(minutes=30)
 REPORT_INTERVAL = timedelta(minutes=5)
+ACTIVE_REPORT_INTERVAL = timedelta(minutes=1)
 DEVICE_VERSION_INTERVAL = timedelta(weeks=1)
 MAP_INTERVAL = timedelta(minutes=60)
 RTK_INTERVAL = timedelta(hours=5)
 SPINO_INTERVAL = timedelta(weeks=1)
+LOCATION_TRAIL_MAX_POINTS = 500
+LOCATION_TRAIL_MIN_DISTANCE_METERS = 0.25
+LIVE_REPORT_MODES = {
+    int(WorkMode.MODE_WORKING),
+    int(WorkMode.MODE_PAUSE),
+    int(WorkMode.MODE_RETURNING),
+}
+EMPTY_GEOJSON = {"type": "FeatureCollection", "features": []}
+
+
+def _distance_meters(first: tuple[float, float], second: tuple[float, float]) -> float:
+    """Return the rough distance between two lon/lat points in metres."""
+    first_lon, first_lat = first
+    second_lon, second_lat = second
+    mean_lat = math.radians((first_lat + second_lat) / 2)
+    metres_per_lat = 111_111.0
+    metres_per_lon = 111_111.0 * max(math.cos(mean_lat), 0.01)
+    return math.hypot(
+        (second_lon - first_lon) * metres_per_lon,
+        (second_lat - first_lat) * metres_per_lat,
+    )
 
 
 class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # type: ignore[misc]
@@ -158,6 +182,8 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         self._subscriptions: list[Subscription] = []
         self.map_offset_lat: float = 0.0
         self.map_offset_lon: float = 0.0
+        self.location_trail: list[tuple[float, float]] = []
+        self._location_trail_active = False
         self._bluetooth_enabled: bool = True
         self._cloud_enabled: bool = True
 
@@ -1542,9 +1568,95 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         """Get coordinator data."""
         return device
 
+    async def async_get_dynamics_line(self) -> None:
+        """Fetch the active mow-progress trail from the mower when supported."""
+        if get_dynamics_line := getattr(self.manager, "get_dynamics_line", None):
+            await get_dynamics_line(self.device_name)
+
+    @staticmethod
+    def _is_live_report_active(device: MowingDevice) -> bool:
+        """Return True when live mowing telemetry should be tracked."""
+        try:
+            return int(device.report_data.dev.sys_status) in LIVE_REPORT_MODES
+        except (TypeError, ValueError):
+            return False
+
+    def _clear_live_location_trail(self, device: MowingDevice) -> None:
+        """Drop stale live trail overlays."""
+        self.location_trail.clear()
+        if getattr(device, "map", None) is None:
+            return
+        device.map.generated_dynamics_line_geojson = EMPTY_GEOJSON.copy()
+        device.map.generated_mow_progress_geojson = EMPTY_GEOJSON.copy()
+
+    def _refresh_poll_interval(self, device: MowingDevice) -> bool:
+        """Use near-live polling only while a task is active."""
+        active = self._is_live_report_active(device)
+        if active != self._location_trail_active or (
+            not active and self.location_trail
+        ):
+            self._clear_live_location_trail(device)
+        self._location_trail_active = active
+        self.update_interval = ACTIVE_REPORT_INTERVAL if active else REPORT_INTERVAL
+        return active
+
+    def _update_location_trail(self, device: MowingDevice | None = None) -> None:
+        """Append the latest mower GPS point to the in-memory trail."""
+        if device is None:
+            device = self.manager.get_device_by_name(self.device_name)
+        if device is None or not self._is_live_report_active(device):
+            return
+
+        location = getattr(getattr(device, "location", None), "device", None)
+        latitude = getattr(location, "latitude", None)
+        longitude = getattr(location, "longitude", None)
+        try:
+            lat = float(latitude)
+            lon = float(longitude)
+        except (TypeError, ValueError):
+            return
+        if not (-90 <= lat <= 90 and -180 <= lon <= 180) or (lat == 0 and lon == 0):
+            return
+
+        point = (lon, lat)
+        if self.location_trail and (
+            _distance_meters(self.location_trail[-1], point)
+            < LOCATION_TRAIL_MIN_DISTANCE_METERS
+        ):
+            return
+        self.location_trail.append(point)
+        if len(self.location_trail) > LOCATION_TRAIL_MAX_POINTS:
+            del self.location_trail[:-LOCATION_TRAIL_MAX_POINTS]
+        self._sync_location_trail_geojson(device)
+
+    def _sync_location_trail_geojson(self, device: MowingDevice) -> None:
+        """Persist the HA GPS trail as a Mammotion map overlay."""
+        if len(self.location_trail) < 2 or getattr(device, "map", None) is None:
+            return
+        device.map.generated_dynamics_line_geojson = {
+            "type": "FeatureCollection",
+            "name": "Mammotion Live Trail",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {
+                        "type_name": "trail",
+                        "Name": "Trail",
+                        "color": "#2377eb",
+                    },
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": self.location_trail[-LOCATION_TRAIL_MAX_POINTS:],
+                    },
+                }
+            ],
+        }
+
     async def _async_update_data(self) -> MowingDevice:
         """Get data from the device."""
         if data := await super()._async_update_data():
+            self._refresh_poll_interval(data)
+            self._update_location_trail(data)
             return data
 
         device = self.manager.get_device_by_name(self.device_name)
@@ -1552,8 +1664,23 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
             LOGGER.debug("device not found")
             return self.data
 
+        active = self._refresh_poll_interval(device)
+        if active:
+            try:
+                await self.async_request_report_snapshot()
+                await self.async_get_dynamics_line()
+            except (DeviceOfflineException, NoTransportAvailableError):
+                LOGGER.debug(
+                    "Skipping live refresh for %s because the device is offline",
+                    self.device_name,
+                )
+                return device
+            if refreshed_device := self.manager.get_device_by_name(self.device_name):
+                device = refreshed_device
+
         LOGGER.debug("Updated Mammotion device %s", self.device_name)
         self.update_failures = 0
+        self._update_location_trail(device)
         await self.async_save_data(device)
 
         if self.data.mower_state.ble_mac != "" and len(self._on_stop) == 0:
@@ -1586,6 +1713,13 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
                         )
 
         return device
+
+    async def _on_state_changed(self, snapshot: DeviceSnapshot) -> None:
+        """Push updated device data to HA."""
+        data = cast(MowingDevice, snapshot.raw)
+        self._refresh_poll_interval(data)
+        self._update_location_trail(data)
+        self.async_set_updated_data(data)
 
     async def _async_update_notification(self, res: tuple[str, Any | None]) -> None:
         """Update data from incoming messages."""
@@ -1633,6 +1767,9 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
             await self.async_read_traversal_mode()
             if DeviceType.is_mini_or_x_series(self.device_name):
                 await self.async_read_manual_light()
+                await self.async_read_night_light()
+                await self.async_read_cutter_mode()
+            elif is_yuka_2(self.device_name):
                 await self.async_read_night_light()
                 await self.async_read_cutter_mode()
             if DeviceType.is_luba_pro(self.device_name):

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -74,6 +74,7 @@ from pymammotion.transport.base import (
     LoginFailedError,
     NoTransportAvailableError,
     ReLoginRequiredError,
+    SagaFailedError,
     SessionExpiredError,
     Subscription,
     TransportType,
@@ -112,6 +113,8 @@ RTK_INTERVAL = timedelta(hours=5)
 SPINO_INTERVAL = timedelta(weeks=1)
 LOCATION_TRAIL_MAX_POINTS = 500
 LOCATION_TRAIL_MIN_DISTANCE_METERS = 0.25
+DYNAMICS_LINE_BACKOFF_SECONDS = 300
+DYNAMICS_LINE_FETCH_ENABLED = False
 LIVE_REPORT_MODES = {
     int(WorkMode.MODE_WORKING),
     int(WorkMode.MODE_PAUSE),
@@ -1587,6 +1590,7 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         )
 
         self._on_stop: list[CALLBACK_TYPE] = []
+        self._next_dynamics_line_fetch_at = 0.0
 
         self.poll_debouncer = Debouncer(
             hass,
@@ -1673,8 +1677,20 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
 
     async def async_get_dynamics_line(self) -> None:
         """Fetch the active mow-progress trail from the mower when supported."""
+        if not DYNAMICS_LINE_FETCH_ENABLED:
+            return
+        now = time.monotonic()
+        if now < self._next_dynamics_line_fetch_at:
+            return
+        self._next_dynamics_line_fetch_at = now + DYNAMICS_LINE_BACKOFF_SECONDS
         if get_dynamics_line := getattr(self.manager, "get_dynamics_line", None):
-            await get_dynamics_line(self.device_name)
+            try:
+                await get_dynamics_line(self.device_name)
+            except (CommandTimeoutError, ConcurrentRequestError, SagaFailedError):
+                LOGGER.debug(
+                    "Backed off Mammotion dynamics-line fetch for %s after timeout",
+                    self.device_name,
+                )
 
     @staticmethod
     def _is_live_report_active(device: MowingDevice) -> bool:
@@ -1771,7 +1787,8 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         if active:
             try:
                 await self.async_request_report_snapshot()
-                await self.async_get_dynamics_line()
+                if int(getattr(device.report_data.dev, "charge_state", 0) or 0) == 0:
+                    await self.async_get_dynamics_line()
             except (DeviceOfflineException, NoTransportAvailableError):
                 LOGGER.debug(
                     "Skipping live refresh for %s because the device is offline",

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -55,6 +55,7 @@ from pymammotion.data.model.device_config import OperationSettings, create_path_
 from pymammotion.data.model.hash_list import AreaHashNameList, Plan, SvgMessage
 from pymammotion.data.model.pool_state import PoolPlan, SpinoToggle
 from pymammotion.data.model.report_info import Maintain, NetUsedType
+from pymammotion.data.model.work import CurrentTaskSettings
 from pymammotion.data.mqtt.event import DeviceNotificationEventParams, ThingEventMessage
 from pymammotion.data.mqtt.properties import ThingPropertiesMessage
 from pymammotion.data.mqtt.status import StatusType, ThingStatusMessage
@@ -420,7 +421,7 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         command: str,
         expected_field: str,
         **kwargs: Any,
-    ) -> None:
+    ) -> Any | None:
         """Send a command and wait for response with standard exception handling.
 
         Handles credential expiry, gateway/transport timeouts, and device-offline
@@ -429,16 +430,18 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         """
         device = self.manager.get_device_by_name(self.device_name)
         if device is None or not self.is_online():
-            return
+            return None
 
         try:
-            await self.manager.send_command_and_wait(
+            response = await self.manager.send_command_and_wait(
                 self.device_name,
                 command,
                 expected_field,
                 prefer_ble=self._bluetooth_enabled,
                 **kwargs,
             )
+            self.update_failures = 0
+            return response
         except EXPIRED_CREDENTIAL_EXCEPTIONS as exc:
             self.update_failures += 1
             await self.async_refresh_login(exc)
@@ -456,8 +459,14 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
             GatewayTimeoutException,
             CommandTimeoutError,
             ConcurrentRequestError,
-        ):
-            pass
+        ) as exc:
+            LOGGER.debug(
+                "Command %s for %s did not receive %s: %s",
+                command,
+                self.device_name,
+                expected_field,
+                exc,
+            )
         except asyncio.CancelledError:
             # bleak_retry_connector raises CancelledError when no BLE slot is
             # available (it cancels its own internal sleep).  Re-raise only when
@@ -470,6 +479,7 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
                 "BLE connection cancelled (no available slot) for %s — skipping",
                 self.device_name,
             )
+        return None
 
     @staticmethod
     def device_offline(device: MowingDevice | RTKBaseStationDevice) -> None:
@@ -1109,11 +1119,15 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         #     and route_information.toward_mode == 0
         # ):
         #     route_information.toward = 0
-        await self.async_send_and_wait(
+        response = await self.async_send_and_wait(
             "generate_route_information",
             "bidire_reqconver_path",
             generate_route_information=route_information,
         )
+        if response is None:
+            return False
+        if not self.sync_operation_settings_from_route_response(response):
+            return False
         return True
 
     async def async_get_plan_route(self, operation_settings: OperationSettings) -> None:
@@ -1143,9 +1157,11 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
 
         route_information = self.generate_route_information(operation_settings)
 
-        return await self.async_send_command(
+        result = await self.async_send_command(
             "modify_route_information", generate_route_information=route_information
         )
+        self.sync_operation_settings_from_current_task()
+        return result
 
     async def start_task(self, plan_id: str) -> None:
         """Start task."""
@@ -1241,9 +1257,96 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         """Return operation settings for planning."""
         return self._operation_settings
 
+    def _current_task_from_route_response(
+        self, response: Any
+    ) -> CurrentTaskSettings | None:
+        """Extract accepted route settings from a route-planning response."""
+        if response is None or getattr(response, "nav", None) is None:
+            return None
+
+        try:
+            nav_msg = betterproto2.which_one_of(response.nav, "SubNavMsg")
+        except (AttributeError, ValueError, KeyError):
+            return None
+
+        if nav_msg[0] != "bidire_reqconver_path":
+            return None
+
+        return CurrentTaskSettings.from_dict(
+            nav_msg[1].to_dict(casing=betterproto2.Casing.SNAKE)
+        )
+
+    def sync_operation_settings_from_route_response(self, response: Any) -> bool:
+        """Mirror accepted route settings from a route-planning ACK."""
+        work = self._current_task_from_route_response(response)
+        if work is None:
+            return False
+        if work.result != 0:
+            LOGGER.debug(
+                "Route planning for %s returned result=%s",
+                self.device_name,
+                work.result,
+            )
+            return False
+
+        device = self.manager.get_device_by_name(self.device_name) or self.data
+        if device is not None:
+            cast(MowingDevice, device).work = work
+        if self.data is not None:
+            cast(MowingDevice, self.data).work = work
+        self._sync_operation_settings_from_work(work)
+        return True
+
+    def sync_operation_settings_from_current_task(self) -> None:
+        """Mirror accepted route settings from the mower's current task."""
+        device = self.manager.get_device_by_name(self.device_name) or self.data
+        if device is None:
+            return
+
+        work = cast(MowingDevice, device).work
+        if work is None:
+            return
+
+        self._sync_operation_settings_from_work(work)
+
+    def _sync_operation_settings_from_work(self, work: CurrentTaskSettings) -> None:
+        """Mirror accepted route settings from current task data."""
+        path_order = GenerateRouteInformation.decode_path_order(work.reserved)
+        self._operation_settings.areas = [
+            area for area in list(dict.fromkeys(work.zone_hashs)) if area
+        ]
+        self._operation_settings.toward = work.toward
+        self._operation_settings.toward_mode = work.toward_mode
+        self._operation_settings.toward_included_angle = work.toward_included_angle
+        self._operation_settings.mowing_laps = work.edge_mode
+        self._operation_settings.obstacle_laps = path_order.obstacle_laps
+        self._operation_settings.rain_tactics = path_order.rain_tactics
+        self._operation_settings.start_progress = path_order.start_progress
+        self._operation_settings.collect_grass_frequency = (
+            path_order.collect_grass_freq
+        )
+        self._operation_settings.job_mode = work.job_mode
+        self._operation_settings.border_mode = work.job_mode
+        self._operation_settings.job_id = work.job_id
+        self._operation_settings.job_version = work.job_ver
+        self._operation_settings.speed = work.speed
+        self._operation_settings.ultra_wave = work.ultra_wave
+        self._operation_settings.channel_mode = work.channel_mode
+        self._operation_settings.channel_width = work.channel_width
+        self._operation_settings.path_order = work.reserved
+        self._operation_settings.blade_height = work.knife_height
+        self.async_update_listeners()
+
     async def async_modify_plan_if_mowing(self) -> None:
         """Re-plan the current mow route if the device is actively mowing."""
         _mdata = cast(MowingDevice, self.data)
+        if (
+            _mdata.report_data.dev.sys_status != WorkMode.MODE_WORKING
+            or _mdata.report_data.dev.charge_state != 0
+        ):
+            return
+        if _mdata.work is None:
+            return
         if (
             int(_mdata.report_data.work.bp_hash) in _mdata.work.zone_hashs
             and (_mdata.report_data.work.area >> 16) != 100

--- a/custom_components/mammotion/image.py
+++ b/custom_components/mammotion/image.py
@@ -1,0 +1,248 @@
+"""Mammotion map image entities."""
+
+from __future__ import annotations
+
+import copy
+import datetime
+import json
+import math
+from typing import Any
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from pymammotion.utility.constant import WorkMode
+
+from . import MammotionConfigEntry
+from .coordinator import MammotionMapUpdateCoordinator, MammotionReportUpdateCoordinator
+from .entity import MammotionBaseEntity
+from .geojson_utils import apply_geojson_offset
+from .map_renderer import placeholder_png, render_map_png
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MammotionConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up map image entities."""
+    async_add_entities(
+        MammotionMapImage(mower.map_coordinator, mower.reporting_coordinator, hass)
+        for mower in entry.runtime_data.mowers
+    )
+
+
+class MammotionMapImage(MammotionBaseEntity, ImageEntity):
+    """Static rendered mower map."""
+
+    _attr_translation_key = "map"
+    _attr_content_type = "image/png"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: MammotionMapUpdateCoordinator,
+        report_coordinator: MammotionReportUpdateCoordinator,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the map image."""
+        MammotionBaseEntity.__init__(self, coordinator, "map")
+        ImageEntity.__init__(self, hass)
+        self._report_coordinator = report_coordinator
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self._cached_png: bytes | None = None
+        self._last_content_key: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh rendered image when live mower telemetry changes."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._report_coordinator.async_add_listener(self._handle_report_update)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Invalidate image when map coordinator changes."""
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        super()._handle_coordinator_update()
+
+    @callback
+    def _handle_report_update(self) -> None:
+        """Invalidate image when live mower position changes."""
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self.async_write_ha_state()
+
+    async def async_image(self) -> bytes | None:
+        """Return a rendered map image."""
+        mower = self.coordinator.manager.get_device_by_name(
+            self.coordinator.device_name
+        )
+        if mower is None:
+            return placeholder_png()
+
+        geojson = self._offset_geojson(mower)
+        mower_location = self._offset_location(mower.location.device)
+        mower_trail = (
+            list(getattr(self._report_coordinator, "location_trail", []))
+            if self._is_live_report_active(mower)
+            else []
+        )
+        content_key = self._content_key(geojson, mower_location, mower_trail)
+        if self._cached_png is not None and content_key == self._last_content_key:
+            return self._cached_png
+
+        tile_cache_dir = self.hass.config.path(".storage", "mammotion_osm_tiles")
+        self._cached_png = await self.hass.async_add_executor_job(
+            render_map_png,
+            copy.deepcopy(geojson),
+            tile_cache_dir,
+            copy.deepcopy(mower_location),
+            copy.deepcopy(mower_trail),
+        )
+        self._last_content_key = content_key
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        return self._cached_png
+
+    def _offset_geojson(self, mower: Any) -> dict[str, Any] | None:
+        geojson = self._merged_geojson(mower)
+        if not geojson:
+            return None
+        return apply_geojson_offset(
+            geojson,
+            self._report_coordinator.map_offset_lat,
+            self._report_coordinator.map_offset_lon,
+        )
+
+    @staticmethod
+    def _merged_geojson(mower: Any) -> dict[str, Any] | None:
+        base_geojson = MammotionMapImage._base_geojson(
+            getattr(mower.map, "generated_geojson", None)
+        )
+        feature_collections = [base_geojson]
+        if MammotionMapImage._is_live_report_active(mower):
+            feature_collections.extend(
+                (
+                    MammotionMapImage._line_geojson(
+                        getattr(mower.map, "generated_mow_progress_geojson", None)
+                    ),
+                    MammotionMapImage._line_geojson(
+                        getattr(mower.map, "generated_dynamics_line_geojson", None)
+                    ),
+                )
+            )
+        features: list[dict[str, Any]] = []
+        for geojson in feature_collections:
+            if isinstance(geojson, dict):
+                features.extend(geojson.get("features") or [])
+        if not features:
+            return None
+        return {
+            "type": "FeatureCollection",
+            "name": "Mammotion Map",
+            "features": features,
+        }
+
+    @staticmethod
+    def _is_live_report_active(mower: Any) -> bool:
+        try:
+            mode = int(mower.report_data.dev.sys_status or 0)
+        except (TypeError, ValueError):
+            return False
+        return mode in {
+            int(WorkMode.MODE_WORKING),
+            int(WorkMode.MODE_RETURNING),
+            int(WorkMode.MODE_PAUSE),
+        }
+
+    @staticmethod
+    def _base_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep persistent map geometry and drop stale route/progress overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if MammotionMapImage._is_base_map_feature(feature)
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _line_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep only line geometry from live task overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if (feature.get("geometry") or {}).get("type")
+            in {"LineString", "MultiLineString"}
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _is_base_map_feature(feature: dict[str, Any]) -> bool:
+        properties = feature.get("properties") or {}
+        type_name = str(
+            properties.get("type_name")
+            or properties.get("type")
+            or properties.get("Type")
+            or ""
+        ).lower()
+        return type_name in {
+            "area",
+            "charging_station",
+            "dump",
+            "no_go_zone",
+            "obstacle",
+            "station",
+            "virtual_wall",
+            "visual_obstacle_zone",
+            "visual_safety_zone",
+        }
+
+    def _offset_location(self, mower_location: Any) -> Any:
+        if mower_location is None:
+            return None
+        location = copy.deepcopy(mower_location)
+        latitude = getattr(location, "latitude", None)
+        longitude = getattr(location, "longitude", None)
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except (TypeError, ValueError):
+            return location
+        location.latitude = (
+            latitude + self._report_coordinator.map_offset_lat / 111_111.0
+        )
+        cos_lat = math.cos(math.radians(location.latitude))
+        if cos_lat != 0:
+            location.longitude = longitude + self._report_coordinator.map_offset_lon / (
+                111_111.0 * cos_lat
+            )
+        return location
+
+    @staticmethod
+    def _content_key(
+        geojson: dict[str, Any] | None,
+        mower_location: Any | None,
+        mower_trail: list[tuple[float, float]],
+    ) -> str:
+        location_key = None
+        if mower_location is not None:
+            location_key = (
+                round(float(getattr(mower_location, "latitude", 0.0) or 0.0), 7),
+                round(float(getattr(mower_location, "longitude", 0.0) or 0.0), 7),
+            )
+        payload = {
+            "geojson": geojson,
+            "location": location_key,
+            "trail": [
+                (round(float(lon), 7), round(float(lat), 7))
+                for lon, lat in mower_trail[-80:]
+            ],
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymammotion.data.model.report_info import DeviceData, ReportData
-from pymammotion.utility.constant.device_constant import WorkMode
+from pymammotion.utility.constant.device_constant import PosType, WorkMode
 from pymammotion.utility.device_type import DeviceType
 
 from . import MammotionConfigEntry
@@ -213,7 +213,10 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
         if mode is None:
             return None
 
+        position_type = self.coordinator.data.location.position_type
         LOGGER.debug("activity mode %s", mode)
+        if mode == WorkMode.MODE_READY and position_type == PosType.CHARGE_ON.value:
+            return LawnMowerActivity.DOCKED
         if mode == WorkMode.MODE_PAUSE or (
             mode == WorkMode.MODE_READY and charge_state == 0
         ):

--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from copy import copy
 from datetime import time
 from typing import Any, cast
@@ -227,12 +228,36 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
             return LawnMowerActivity.DOCKED
         return None
 
+    async def _async_wait_for_modes(
+        self, modes: set[WorkMode], attempts: int = 15
+    ) -> bool:
+        """Wait for the mower to report one of the expected work modes."""
+        for _ in range(attempts):
+            await self.coordinator.async_request_report_snapshot()
+            if self.rpt_dev_status.sys_status in modes:
+                return True
+            await asyncio.sleep(1)
+        await self.coordinator.async_request_report_snapshot()
+        return self.rpt_dev_status.sys_status in modes
+
+    async def _async_start_job_and_verify(self, trans_key: str) -> None:
+        """Start the planned job and verify the mower actually begins work."""
+        if not await self.coordinator.async_send_command("start_job"):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key=trans_key
+            )
+        if not await self._async_wait_for_modes({WorkMode.MODE_WORKING}):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key=trans_key
+            )
+
     async def async_start_mowing(self, **kwargs: Any) -> None:
         """Start mowing."""
         trans_key = "pause_failed"
 
         await self.coordinator.async_ensure_fresh_state()
 
+        explicit_route = bool(kwargs)
         if kwargs:
             entity_ids = kwargs.pop("areas", [])
             attributes = [
@@ -281,8 +306,22 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
                     await self.coordinator.async_modify_plan_route(operational_settings)
                     return
 
-                if kwargs:
+                if explicit_route:
                     await self.async_cancel()
+                    await self.coordinator.async_request_report_snapshot()
+                    for _ in range(5):
+                        mode = self.rpt_dev_status.sys_status
+                        if mode != WorkMode.MODE_PAUSE:
+                            break
+                        await asyncio.sleep(1)
+                        await self.coordinator.async_request_report_snapshot()
+                    mode = self.rpt_dev_status.sys_status
+                    breakpoint_info = 0
+                    if (
+                        mode == WorkMode.MODE_PAUSE
+                        and self.rpt_dev_status.charge_state != 0
+                    ):
+                        mode = WorkMode.MODE_READY
 
                 if mode == WorkMode.MODE_RETURNING:
                     trans_key = "dock_cancel_failed"
@@ -295,23 +334,38 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
                     trans_key = "resume_failed"
                     if breakpoint_info != 0:
                         await self.coordinator.async_send_command("resume_execute_task")
-                        await self.coordinator.async_send_and_wait(
+                        response = await self.coordinator.async_send_and_wait(
                             "query_generate_route_information", "bidire_reqconver_path"
                         )
+                        if not self.coordinator.sync_operation_settings_from_route_response(
+                            response
+                        ):
+                            raise HomeAssistantError(
+                                translation_domain=DOMAIN, translation_key=trans_key
+                            )
                 if mode in (WorkMode.MODE_READY, WorkMode.MODE_INITIALIZATION):
                     trans_key = "start_failed"
                     if breakpoint_info != 0:
-                        await self.coordinator.async_send_and_wait(
+                        response = await self.coordinator.async_send_and_wait(
                             "query_generate_route_information", "bidire_reqconver_path"
                         )
-                        if not plan_only:
-                            await self.coordinator.async_send_command("start_job")
-                        return
-                    if await self.coordinator.async_plan_route(operational_settings):
-                        if not plan_only:
-                            await self.coordinator.async_send_and_wait(
-                                "start_job", "zone_start_precent_t"
+                        if not self.coordinator.sync_operation_settings_from_route_response(
+                            response
+                        ):
+                            raise HomeAssistantError(
+                                translation_domain=DOMAIN, translation_key=trans_key
                             )
+                        if not plan_only:
+                            await self._async_start_job_and_verify(trans_key)
+                        return
+                    if not await self.coordinator.async_plan_route(
+                        operational_settings
+                    ):
+                        raise HomeAssistantError(
+                            translation_domain=DOMAIN, translation_key=trans_key
+                        )
+                    if not plan_only:
+                        await self._async_start_job_and_verify(trans_key)
 
             except COMMAND_EXCEPTIONS as exc:
                 raise HomeAssistantError(

--- a/custom_components/mammotion/map_renderer.py
+++ b/custom_components/mammotion/map_renderer.py
@@ -1,0 +1,493 @@
+"""Static Mammotion map renderer."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from PIL import Image, ImageColor, ImageDraw
+
+CANVAS_SIZE = (1024, 768)
+BACKGROUND = (245, 245, 245, 255)
+AREA_FILL = (59, 191, 97, 75)
+AREA_STROKE = (59, 191, 97, 255)
+OBSTACLE_FILL = (255, 149, 20, 85)
+OBSTACLE_STROKE = (255, 149, 20, 230)
+PATH_STROKE = (45, 45, 45, 240)
+TRAIL_STROKE = (35, 119, 235, 170)
+TRAIL_RECENT_STROKE = (35, 119, 235, 230)
+VIRTUAL_STROKE = (220, 40, 40, 230)
+MOWER_FILL = (35, 119, 235, 255)
+MOWER_STROKE = (255, 255, 255, 255)
+OSM_MAX_ZOOM = 19
+OSM_TILE_SIZE = 256
+OSM_TILE_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+OSM_USER_AGENT = "HomeAssistant-Mammotion-Map/1.0"
+
+
+@dataclass(frozen=True)
+class GeoBounds:
+    """Geographic bounds in WGS84 lon/lat."""
+
+    min_lon: float
+    min_lat: float
+    max_lon: float
+    max_lat: float
+
+    @property
+    def width(self) -> float:
+        return self.max_lon - self.min_lon
+
+    @property
+    def height(self) -> float:
+        return self.max_lat - self.min_lat
+
+    @property
+    def center(self) -> tuple[float, float]:
+        return (
+            (self.min_lon + self.max_lon) / 2,
+            (self.min_lat + self.max_lat) / 2,
+        )
+
+    def expanded(self) -> GeoBounds:
+        center_lat = self.center[1]
+        pad_lat = max(self.height * 0.08, _meters_to_lat_degrees(3.0))
+        pad_lon = max(self.width * 0.08, _meters_to_lon_degrees(3.0, center_lat))
+        return GeoBounds(
+            self.min_lon - pad_lon,
+            self.min_lat - pad_lat,
+            self.max_lon + pad_lon,
+            self.max_lat + pad_lat,
+        )
+
+
+def placeholder_png() -> bytes:
+    """Return a placeholder when map geometry is not available."""
+    image = Image.new("RGBA", CANVAS_SIZE, BACKGROUND)
+    draw = ImageDraw.Draw(image)
+    text = "No mower map available yet"
+    text_bounds = draw.textbbox((0, 0), text)
+    draw.text(
+        (
+            (CANVAS_SIZE[0] - (text_bounds[2] - text_bounds[0])) / 2,
+            (CANVAS_SIZE[1] - (text_bounds[3] - text_bounds[1])) / 2,
+        ),
+        text,
+        fill=(120, 120, 120, 255),
+    )
+    return _encode(image)
+
+
+def render_map_png(
+    geojson: dict[str, Any] | None,
+    tile_cache_dir: str | None = None,
+    mower_location: Any | None = None,
+    mower_trail: list[tuple[float, float]] | None = None,
+) -> bytes:
+    """Render a Mammotion GeoJSON map into a static PNG."""
+    mower_point = _geo_location_point(mower_location)
+    trail_points = _valid_geo_points(mower_trail or [])
+    points = _geometry_points(geojson or {})
+    points.extend(trail_points)
+    if mower_point is not None:
+        points.append(mower_point)
+    if not points:
+        return placeholder_png()
+
+    bounds = _geo_bounds(points).expanded()
+    center_lon, center_lat = bounds.center
+    zoom = OSM_MAX_ZOOM
+    min_pixel = _lonlat_to_pixel(bounds.min_lon, bounds.max_lat, zoom)
+    max_pixel = _lonlat_to_pixel(bounds.max_lon, bounds.min_lat, zoom)
+    pixel_width = max(max_pixel[0] - min_pixel[0], 1.0)
+    pixel_height = max(max_pixel[1] - min_pixel[1], 1.0)
+    scale = min(
+        (CANVAS_SIZE[0] * 0.90) / pixel_width,
+        (CANVAS_SIZE[1] * 0.90) / pixel_height,
+    )
+    scale = max(min(scale, 8.0), 0.2)
+
+    center_pixel = _lonlat_to_pixel(center_lon, center_lat, zoom)
+    source_width = CANVAS_SIZE[0] / scale
+    source_height = CANVAS_SIZE[1] / scale
+    source_min_x = center_pixel[0] - source_width / 2
+    source_min_y = center_pixel[1] - source_height / 2
+    source = _render_osm_source(
+        zoom,
+        source_min_x,
+        source_min_y,
+        source_width,
+        source_height,
+        tile_cache_dir,
+    )
+    image = source.resize(CANVAS_SIZE, Image.Resampling.BICUBIC)
+    draw = ImageDraw.Draw(image, "RGBA")
+
+    def project(coord: tuple[float, float]) -> tuple[float, float]:
+        pixel_x, pixel_y = _lonlat_to_pixel(coord[0], coord[1], zoom)
+        return (
+            (pixel_x - source_min_x) * scale,
+            (pixel_y - source_min_y) * scale,
+        )
+
+    for feature in (geojson or {}).get("features", []):
+        _draw_geojson_feature(draw, feature, project)
+
+    _draw_trail(draw, trail_points, project)
+
+    if mower_point is not None:
+        _draw_mower_marker(draw, project(mower_point))
+
+    return _encode(image)
+
+
+def _render_osm_source(
+    zoom: int,
+    source_min_x: float,
+    source_min_y: float,
+    source_width: float,
+    source_height: float,
+    tile_cache_dir: str | None,
+) -> Image.Image:
+    source = Image.new(
+        "RGBA",
+        (math.ceil(source_width), math.ceil(source_height)),
+        BACKGROUND,
+    )
+    max_tile = (2**zoom) - 1
+    min_tile_x = max(math.floor(source_min_x / OSM_TILE_SIZE), 0)
+    max_tile_x = min(
+        math.floor((source_min_x + source_width) / OSM_TILE_SIZE), max_tile
+    )
+    min_tile_y = max(math.floor(source_min_y / OSM_TILE_SIZE), 0)
+    max_tile_y = min(
+        math.floor((source_min_y + source_height) / OSM_TILE_SIZE), max_tile
+    )
+
+    for tile_x in range(min_tile_x, max_tile_x + 1):
+        for tile_y in range(min_tile_y, max_tile_y + 1):
+            tile = _load_osm_tile(zoom, tile_x, tile_y, tile_cache_dir)
+            if tile is None:
+                continue
+            source.alpha_composite(
+                tile.convert("RGBA"),
+                (
+                    round(tile_x * OSM_TILE_SIZE - source_min_x),
+                    round(tile_y * OSM_TILE_SIZE - source_min_y),
+                ),
+            )
+    return source
+
+
+def _load_osm_tile(
+    zoom: int, tile_x: int, tile_y: int, tile_cache_dir: str | None
+) -> Image.Image | None:
+    cache_path: Path | None = None
+    if tile_cache_dir:
+        cache_path = Path(tile_cache_dir) / str(zoom) / str(tile_x) / f"{tile_y}.png"
+        if cache_path.exists():
+            try:
+                return Image.open(cache_path).copy()
+            except OSError:
+                cache_path.unlink(missing_ok=True)
+
+    request = Request(
+        OSM_TILE_URL.format(z=zoom, x=tile_x, y=tile_y),
+        headers={"User-Agent": OSM_USER_AGENT},
+    )
+    try:
+        with urlopen(request, timeout=5) as response:
+            tile_bytes = response.read()
+    except (HTTPError, OSError, TimeoutError, URLError):
+        return None
+
+    if cache_path:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(tile_bytes)
+
+    try:
+        return Image.open(BytesIO(tile_bytes)).copy()
+    except OSError:
+        return None
+
+
+def _draw_geojson_feature(
+    draw: ImageDraw.ImageDraw, feature: dict[str, Any], project
+) -> None:
+    geometry = feature.get("geometry") or {}
+    properties = feature.get("properties") or {}
+    geometry_type = geometry.get("type")
+    type_name = str(properties.get("type_name", "")).lower()
+    name = properties.get("Name") or properties.get("title")
+    stroke, fill = _feature_colours(type_name, properties)
+
+    if geometry_type == "Polygon":
+        for ring in geometry.get("coordinates", []):
+            polygon = [project((float(coord[0]), float(coord[1]))) for coord in ring]
+            if len(polygon) >= 3:
+                draw.polygon(polygon, fill=fill, outline=stroke)
+                draw.line(polygon + [polygon[0]], fill=stroke, width=3, joint="curve")
+        if name and type_name == "area":
+            _draw_label(draw, str(name), _centroid(_geometry_points(geometry)), project)
+    elif geometry_type == "MultiPolygon":
+        for polygon_coordinates in geometry.get("coordinates", []):
+            for ring in polygon_coordinates:
+                polygon = [
+                    project((float(coord[0]), float(coord[1]))) for coord in ring
+                ]
+                if len(polygon) >= 3:
+                    draw.polygon(polygon, fill=fill, outline=stroke)
+                    draw.line(
+                        polygon + [polygon[0]], fill=stroke, width=3, joint="curve"
+                    )
+    elif geometry_type in {"LineString", "MultiLineString"}:
+        lines = (
+            [geometry.get("coordinates", [])]
+            if geometry_type == "LineString"
+            else geometry.get("coordinates", [])
+        )
+        for coordinates in lines:
+            line = [
+                project((float(coord[0]), float(coord[1]))) for coord in coordinates
+            ]
+            if len(line) >= 2:
+                draw.line(line, fill=stroke, width=4, joint="curve")
+    elif geometry_type == "Point":
+        coord = geometry.get("coordinates", [])
+        if len(coord) < 2:
+            return
+        center = project((float(coord[0]), float(coord[1])))
+        radius = 8 if type_name == "station" else 6
+        draw.ellipse(
+            (
+                center[0] - radius,
+                center[1] - radius,
+                center[0] + radius,
+                center[1] + radius,
+            ),
+            fill=fill,
+            outline=stroke,
+            width=2,
+        )
+        if name:
+            _draw_text(draw, str(name), (center[0] + 10, center[1] - 6))
+
+
+def _draw_mower_marker(draw: ImageDraw.ImageDraw, center: tuple[float, float]) -> None:
+    radius = 12
+    draw.ellipse(
+        (
+            center[0] - radius - 3,
+            center[1] - radius - 3,
+            center[0] + radius + 3,
+            center[1] + radius + 3,
+        ),
+        fill=(0, 0, 0, 70),
+    )
+    draw.ellipse(
+        (
+            center[0] - radius,
+            center[1] - radius,
+            center[0] + radius,
+            center[1] + radius,
+        ),
+        fill=MOWER_FILL,
+        outline=MOWER_STROKE,
+        width=4,
+    )
+    draw.ellipse(
+        (center[0] - 4, center[1] - 4, center[0] + 4, center[1] + 4),
+        fill=(255, 255, 255, 255),
+    )
+
+
+def _draw_trail(
+    draw: ImageDraw.ImageDraw,
+    trail_points: list[tuple[float, float]],
+    project,
+) -> None:
+    if len(trail_points) < 2:
+        return
+    line = [project(point) for point in trail_points]
+    draw.line(line, fill=TRAIL_STROKE, width=5, joint="curve")
+    recent = line[-min(len(line), 40) :]
+    if len(recent) >= 2:
+        draw.line(recent, fill=TRAIL_RECENT_STROKE, width=7, joint="curve")
+
+
+def _feature_colours(
+    type_name: str, properties: dict[str, Any]
+) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+    if type_name == "area":
+        return AREA_STROKE, AREA_FILL
+    if type_name in {"obstacle", "visual_obstacle_zone", "visual_safety_zone"}:
+        return OBSTACLE_STROKE, OBSTACLE_FILL
+    if type_name == "path":
+        return PATH_STROKE, (45, 45, 45, 120)
+    if type_name == "trail":
+        return TRAIL_RECENT_STROKE, TRAIL_STROKE
+    if type_name == "station":
+        colour = _parse_colour(properties.get("color"), (90, 78, 181, 255))
+        return colour, (*colour[:3], 180)
+    if type_name == "virtual_wall":
+        return VIRTUAL_STROKE, VIRTUAL_STROKE
+    stroke = _parse_colour(properties.get("color"), PATH_STROKE)
+    fill_colour = _parse_colour(properties.get("fillColor"), (*stroke[:3], 85))
+    return stroke, (*fill_colour[:3], min(fill_colour[3], 110))
+
+
+def _parse_colour(
+    value: Any, fallback: tuple[int, int, int, int]
+) -> tuple[int, int, int, int]:
+    if not value:
+        return fallback
+    try:
+        return ImageColor.getcolor(str(value), "RGBA")
+    except ValueError:
+        return fallback
+
+
+def _draw_label(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    coord: tuple[float, float] | None,
+    project,
+) -> None:
+    if coord is not None:
+        _draw_text(draw, text, project(coord))
+
+
+def _draw_text(draw: ImageDraw.ImageDraw, text: str, xy: tuple[float, float]) -> None:
+    text_bounds = draw.textbbox((0, 0), text)
+    text_width = text_bounds[2] - text_bounds[0]
+    text_height = text_bounds[3] - text_bounds[1]
+    x, y = xy
+    padding = 4
+    draw.rounded_rectangle(
+        (
+            x - padding,
+            y - padding,
+            x + text_width + padding,
+            y + text_height + padding,
+        ),
+        radius=5,
+        fill=(255, 255, 255, 210),
+        outline=(60, 60, 60, 90),
+    )
+    draw.text((x, y), text, fill=(30, 30, 30, 255))
+
+
+def _geometry_points(value: Any) -> list[tuple[float, float]]:
+    if not isinstance(value, dict):
+        return []
+    geometry_type = value.get("type")
+    if geometry_type == "FeatureCollection":
+        return [
+            point
+            for feature in value.get("features", [])
+            for point in _geometry_points(feature)
+        ]
+    if geometry_type == "Feature":
+        return _geometry_points(value.get("geometry") or {})
+    if geometry_type == "GeometryCollection":
+        return [
+            point
+            for geometry in value.get("geometries", [])
+            for point in _geometry_points(geometry)
+        ]
+    return _coordinate_points(value.get("coordinates", []))
+
+
+def _coordinate_points(coordinates: Any) -> list[tuple[float, float]]:
+    if (
+        isinstance(coordinates, list)
+        and len(coordinates) >= 2
+        and isinstance(coordinates[0], int | float)
+        and isinstance(coordinates[1], int | float)
+    ):
+        lon = float(coordinates[0])
+        lat = float(coordinates[1])
+        if -180 <= lon <= 180 and -90 <= lat <= 90:
+            return [(lon, lat)]
+        return []
+    if isinstance(coordinates, list):
+        return [point for item in coordinates for point in _coordinate_points(item)]
+    return []
+
+
+def _geo_bounds(points: list[tuple[float, float]]) -> GeoBounds:
+    return GeoBounds(
+        min(point[0] for point in points),
+        min(point[1] for point in points),
+        max(point[0] for point in points),
+        max(point[1] for point in points),
+    )
+
+
+def _centroid(points: list[tuple[float, float]]) -> tuple[float, float] | None:
+    if not points:
+        return None
+    return (
+        sum(point[0] for point in points) / len(points),
+        sum(point[1] for point in points) / len(points),
+    )
+
+
+def _lonlat_to_pixel(lon: float, lat: float, zoom: int) -> tuple[float, float]:
+    lat = max(min(lat, 85.05112878), -85.05112878)
+    sin_lat = math.sin(math.radians(lat))
+    world_size = OSM_TILE_SIZE * (2**zoom)
+    return (
+        (lon + 180.0) / 360.0 * world_size,
+        (0.5 - math.log((1 + sin_lat) / (1 - sin_lat)) / (4 * math.pi))
+        * world_size,
+    )
+
+
+def _meters_to_lat_degrees(meters: float) -> float:
+    return meters / 111_111.0
+
+
+def _meters_to_lon_degrees(meters: float, lat: float) -> float:
+    return meters / (111_111.0 * max(math.cos(math.radians(lat)), 0.01))
+
+
+def _geo_location_point(location: Any | None) -> tuple[float, float] | None:
+    if location is None:
+        return None
+    latitude = getattr(location, "latitude", None)
+    longitude = getattr(location, "longitude", None)
+    try:
+        latitude = float(latitude)
+        longitude = float(longitude)
+    except (TypeError, ValueError):
+        return None
+    if -90 <= latitude <= 90 and -180 <= longitude <= 180 and (
+        latitude != 0 or longitude != 0
+    ):
+        return longitude, latitude
+    return None
+
+
+def _valid_geo_points(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    valid_points: list[tuple[float, float]] = []
+    for point in points:
+        try:
+            lon = float(point[0])
+            lat = float(point[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if -180 <= lon <= 180 and -90 <= lat <= 90 and (lat != 0 or lon != 0):
+            valid_points.append((lon, lat))
+    return valid_points
+
+
+def _encode(image: Image.Image) -> bytes:
+    buffer = BytesIO()
+    image.save(buffer, "PNG", optimize=True)
+    return buffer.getvalue()

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -14,21 +14,29 @@ from homeassistant.components.number import (
 from homeassistant.const import (
     DEGREE,
     PERCENTAGE,
-    UnitOfArea,
     UnitOfLength,
     UnitOfSpeed,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymammotion.data.model.device import PoolCleanerDevice
 from pymammotion.data.model.device_limits import DeviceLimits
+from pymammotion.data.model.mowing_modes import PathAngleSetting
 from pymammotion.utility.device_config import DeviceConfig
 from pymammotion.utility.device_type import DeviceType
 
 from . import MammotionConfigEntry
 from .coordinator import MammotionBaseUpdateCoordinator, MammotionSpinoCoordinator
+from .const import DOMAIN
 from .entity import MammotionBaseEntity, MammotionBaseSpinoEntity
+from .yuka import (
+    GRID_PATTERN_VALUE,
+    STRIPES_PATTERN_VALUE,
+    is_yuka_2,
+    is_yuka_mini_or_ml,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -40,6 +48,7 @@ class MammotionConfigNumberEntityDescription(NumberEntityDescription):  # type: 
         Callable[[MammotionBaseUpdateCoordinator[Any], float], Awaitable[None]] | None
     ) = None
     get_fn: Callable[[MammotionBaseUpdateCoordinator[Any]], float | None] | None = None
+    available_fn: Callable[[MammotionBaseUpdateCoordinator[Any]], bool] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -140,15 +149,44 @@ NUMBER_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
 
 YUKA_NUMBER_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
     MammotionConfigNumberEntityDescription(
-        key="dumping_interval",
-        native_min_value=5,
-        native_max_value=100,
-        native_step=1,
-        mode=NumberMode.SLIDER,
-        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
+        key="working_speed",
+        device_class=NumberDeviceClass.SPEED,
+        native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+        native_step=0.1,
+        native_min_value=0.2,
+        native_max_value=0.6,
+        set_async_fn=lambda coordinator,
+        value: coordinator.async_modify_plan_if_mowing(),
         set_fn=lambda coordinator, value: setattr(
-            coordinator.operation_settings, "collect_grass_frequency", value
+            coordinator.operation_settings, "speed", value
         ),
+    ),
+    MammotionConfigNumberEntityDescription(
+        key="path_spacing",
+        native_step=1,
+        device_class=NumberDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.CENTIMETERS,
+        native_min_value=8,
+        native_max_value=12,
+        set_async_fn=lambda coordinator,
+        value: coordinator.async_modify_plan_if_mowing(),
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "channel_width", value
+        ),
+    ),
+    MammotionConfigNumberEntityDescription(
+        key="pattern_angle",
+        native_step=1,
+        native_unit_of_measurement=DEGREE,
+        native_min_value=-180,
+        native_max_value=180,
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "toward", value
+        ),
+        available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
+        in (STRIPES_PATTERN_VALUE, GRID_PATTERN_VALUE)
+        and coordinator.operation_settings.toward_mode
+        == PathAngleSetting.absolute_angle.value,
     ),
 )
 
@@ -208,12 +246,23 @@ async def async_setup_entry(
     mammotion_devices = entry.runtime_data.mowers
 
     for mower in mammotion_devices:
+        _cleanup_removed_yuka_2_numbers(hass, mower.device.device_name)
         limits: DeviceLimits | None = DeviceConfig().get_working_parameters(
             mower.device.product_key
         )
         if handle := mower.api.get_device_by_name(mower.name):
             limits = handle.device_limits
         entities: list[MammotionConfigNumberEntity] = []
+
+        if is_yuka_2(mower.device.device_name):
+            for entity_description in (*YUKA_NUMBER_ENTITIES, *MAP_OFFSET_ENTITIES):
+                entities.append(
+                    MammotionWorkingNumberEntity(
+                        mower.reporting_coordinator, entity_description, None
+                    )
+                )
+            async_add_entities(entities)
+            continue
 
         for entity_description in NUMBER_WORKING_ENTITIES:
             entities.append(
@@ -244,7 +293,7 @@ async def async_setup_entry(
                 )
             )
 
-        if DeviceType.is_yuka(mower.device.device_name) and not DeviceType.is_yuka_mini(
+        if DeviceType.is_yuka(mower.device.device_name) and not is_yuka_mini_or_ml(
             mower.device.device_name
         ):
             for entity_description in YUKA_NUMBER_ENTITIES:
@@ -268,6 +317,25 @@ async def async_setup_entry(
             MammotionSpinoNumberEntity(spino.coordinator, entity_description)
             for entity_description in SPINO_NUMBER_ENTITIES
         )
+
+
+def _cleanup_removed_yuka_2_numbers(hass: HomeAssistant, device_name: str) -> None:
+    """Remove number entities that are not exposed by the Yuka app controls."""
+    if not is_yuka_2(device_name):
+        return
+    registry = er.async_get(hass)
+    for key in (
+        "voice_volume",
+        "start_progress",
+        "cutting_angle",
+        "toward_included_angle",
+        "dumping_interval",
+    ):
+        entity_id = registry.async_get_entity_id(
+            "number", DOMAIN, f"{device_name}_{key}"
+        )
+        if entity_id:
+            registry.async_remove(entity_id)
 
 
 class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: ignore[misc]
@@ -319,6 +387,7 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
             self.entity_description.set_fn(self.coordinator, value)
         if self.entity_description.set_async_fn is not None:
             await self.entity_description.set_async_fn(self.coordinator, value)
+        self.coordinator.async_update_listeners()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -333,6 +402,16 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
                 self.entity_description.set_fn(
                     self.coordinator, cast(float, self._attr_native_value)
                 )
+                self.coordinator.async_update_listeners()
+
+    @property
+    def available(self) -> bool:
+        """Return True when this number applies to the current Yuka settings."""
+        if self.entity_description.available_fn is None:
+            return super().available
+        return super().available and self.entity_description.available_fn(
+            self.coordinator
+        )
 
 
 class MammotionWorkingNumberEntity(MammotionConfigNumberEntity):
@@ -384,6 +463,7 @@ class MammotionWorkingNumberEntity(MammotionConfigNumberEntity):
             self.entity_description.set_fn(self.coordinator, value)
         if self.entity_description.set_async_fn is not None:
             await self.entity_description.set_async_fn(self.coordinator, value)
+        self.coordinator.async_update_listeners()
         self.async_write_ha_state()
 
 

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -160,6 +160,7 @@ YUKA_NUMBER_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "speed", value
         ),
+        get_fn=lambda coordinator: coordinator.operation_settings.speed,
     ),
     MammotionConfigNumberEntityDescription(
         key="path_spacing",
@@ -173,6 +174,7 @@ YUKA_NUMBER_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "channel_width", value
         ),
+        get_fn=lambda coordinator: coordinator.operation_settings.channel_width,
     ),
     MammotionConfigNumberEntityDescription(
         key="pattern_angle",
@@ -183,6 +185,7 @@ YUKA_NUMBER_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "toward", value
         ),
+        get_fn=lambda coordinator: coordinator.operation_settings.toward,
         available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
         in (STRIPES_PATTERN_VALUE, GRID_PATTERN_VALUE)
         and coordinator.operation_settings.toward_mode

--- a/custom_components/mammotion/select.py
+++ b/custom_components/mammotion/select.py
@@ -66,6 +66,7 @@ class MammotionConfigSelectEntityDescription(SelectEntityDescription):
     key: str
     options: list[str]
     set_fn: Callable[[MammotionBaseUpdateCoordinator, str], None]
+    get_fn: Callable[[MammotionBaseUpdateCoordinator], str | None] | None = None
     default_option: str | None = None
     async_set_fn: (
         Callable[[MammotionBaseUpdateCoordinator], Awaitable[None]] | None
@@ -221,6 +222,65 @@ def _set_yuka_mow_order(
     coordinator.operation_settings.job_mode = value
 
 
+def _value_option(options: list[str], value: int, values: dict[str, int]) -> str:
+    """Return the option matching a numeric operation setting."""
+    for option, option_value in values.items():
+        if option_value == value and option in options:
+            return option
+    return options[0]
+
+
+def _get_yuka_mow_order(coordinator: MammotionBaseUpdateCoordinator) -> str:
+    """Return the selected Yuka mow order from operation settings."""
+    values = {order.name: order.value for order in MowOrder}
+    return _value_option(
+        [order.name for order in MowOrder], coordinator.operation_settings.job_mode, values
+    )
+
+
+def _get_yuka_lap(
+    coordinator: MammotionBaseUpdateCoordinator, setting: str
+) -> str:
+    """Return the selected Yuka lap option from operation settings."""
+    return _value_option(
+        LAP_OPTIONS, getattr(coordinator.operation_settings, setting), LAP_VALUES
+    )
+
+
+def _get_yuka_obstacle_detection(
+    coordinator: MammotionBaseUpdateCoordinator,
+) -> str:
+    """Return the selected Yuka obstacle detection option."""
+    return _value_option(
+        OBSTACLE_OPTIONS,
+        coordinator.operation_settings.ultra_wave,
+        OBSTACLE_VALUES,
+    )
+
+
+def _get_pattern_family(coordinator: MammotionBaseUpdateCoordinator) -> str:
+    """Return the selected Yuka pattern family from operation settings."""
+    return _value_option(
+        PATTERN_FAMILY_OPTIONS,
+        coordinator.operation_settings.channel_mode,
+        PATTERN_FAMILY_VALUES,
+    )
+
+
+def _get_pattern_variant(
+    coordinator: MammotionBaseUpdateCoordinator, options: list[str]
+) -> str:
+    """Return the selected app-level pattern variant from operation settings."""
+    value = coordinator.operation_settings.toward_mode
+    if value == PathAngleSetting.relative_angle.value:
+        return "efficient" if "efficient" in options else "default"
+    if value == PathAngleSetting.random_angle.value:
+        return "random"
+    if value == PathAngleSetting.absolute_angle.value:
+        return "custom"
+    return options[0]
+
+
 SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
     MammotionConfigSelectEntityDescription(
         key="channel_mode",
@@ -259,12 +319,14 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="border_mode",
         options=[order.name for order in MowOrder],
         default_option=MowOrder.border_first.name,
+        get_fn=_get_yuka_mow_order,
         set_fn=_set_yuka_mow_order,
     ),
     MammotionConfigSelectEntityDescription(
         key="mowing_laps",
         options=LAP_OPTIONS,
         default_option="three",
+        get_fn=lambda coordinator: _get_yuka_lap(coordinator, "mowing_laps"),
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "mowing_laps", LAP_VALUES[value]
         ),
@@ -273,6 +335,7 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="obstacle_laps",
         options=LAP_OPTIONS,
         default_option="none",
+        get_fn=lambda coordinator: _get_yuka_lap(coordinator, "obstacle_laps"),
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "obstacle_laps", LAP_VALUES[value]
         ),
@@ -281,6 +344,7 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="bypass_mode",
         options=OBSTACLE_OPTIONS,
         default_option="standard",
+        get_fn=_get_yuka_obstacle_detection,
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "ultra_wave", OBSTACLE_VALUES[value]
         ),
@@ -290,6 +354,7 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="pattern_family",
         options=PATTERN_FAMILY_OPTIONS,
         default_option="grid",
+        get_fn=_get_pattern_family,
         set_fn=_set_pattern_family,
         async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
     ),
@@ -297,6 +362,9 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="stripes_pattern",
         options=STRIPES_PATTERN_OPTIONS,
         default_option="random",
+        get_fn=lambda coordinator: _get_pattern_variant(
+            coordinator, STRIPES_PATTERN_OPTIONS
+        ),
         set_fn=_set_stripes_pattern,
         async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
         available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
@@ -306,6 +374,9 @@ YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         key="grid_pattern",
         options=GRID_PATTERN_OPTIONS,
         default_option="random",
+        get_fn=lambda coordinator: _get_pattern_variant(
+            coordinator, GRID_PATTERN_OPTIONS
+        ),
         set_fn=_set_grid_pattern,
         async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
         available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
@@ -548,7 +619,17 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
         self._attr_current_option = (
             entity_description.default_option or entity_description.options[0]
         )
-        self.entity_description.set_fn(self.coordinator, self._attr_current_option)
+        self._attr_current_option = self._resolve_option()
+        if self.entity_description.get_fn is None:
+            self.entity_description.set_fn(self.coordinator, self._attr_current_option)
+
+    def _resolve_option(self) -> str:
+        """Return the current option from coordinator operation settings."""
+        if self.entity_description.get_fn is not None:
+            option = self.entity_description.get_fn(self.coordinator)
+            if option in self._attr_options:
+                return option
+        return self._attr_current_option
 
     async def async_select_option(self, option: str) -> None:
         """Select an option."""
@@ -558,6 +639,12 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
             await self.entity_description.async_set_fn(self.coordinator)
         self.coordinator.async_update_listeners()
         self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_current_option = self._resolve_option()
+        super()._handle_coordinator_update()
 
     async def async_added_to_hass(self) -> None:
         """Restore last state."""

--- a/custom_components/mammotion/select.py
+++ b/custom_components/mammotion/select.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from pymammotion.data.model.device import PoolCleanerDevice
@@ -30,7 +31,32 @@ from pymammotion.utility.device_type import DeviceType
 
 from . import MammotionConfigEntry, MammotionReportUpdateCoordinator
 from .coordinator import MammotionBaseUpdateCoordinator, MammotionSpinoCoordinator
+from .const import DOMAIN
 from .entity import MammotionBaseEntity, MammotionBaseSpinoEntity
+from .yuka import (
+    BLADE_SPEED_OPTIONS,
+    BLADE_SPEED_VALUES,
+    GRID_PATTERN_OPTIONS,
+    GRID_PATTERN_VALUE,
+    LAP_OPTIONS,
+    LAP_VALUES,
+    OBSTACLE_OPTIONS,
+    OBSTACLE_VALUES,
+    PATTERN_FAMILY_OPTIONS,
+    PATTERN_FAMILY_VALUES,
+    ROUTE_TO_DOCK_OPTIONS,
+    ROUTE_TO_DOCK_VALUES,
+    STRIPES_PATTERN_OPTIONS,
+    STRIPES_PATTERN_VALUE,
+    VOICE_VOLUME_LEVEL_OPTIONS,
+    VOICE_VOLUME_VALUES,
+    WILDLIFE_SAFETY_OPTIONS,
+    WILDLIFE_SAFETY_VALUES,
+    is_yuka_2,
+    is_yuka_mini_or_ml,
+    voice_volume_option,
+    yuka_value_option,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -40,7 +66,11 @@ class MammotionConfigSelectEntityDescription(SelectEntityDescription):
     key: str
     options: list[str]
     set_fn: Callable[[MammotionBaseUpdateCoordinator, str], None]
-    async_set_fn: Callable[[MammotionBaseUpdateCoordinator], Awaitable[None]] = None
+    default_option: str | None = None
+    async_set_fn: (
+        Callable[[MammotionBaseUpdateCoordinator], Awaitable[None]] | None
+    ) = None
+    available_fn: Callable[[MammotionBaseUpdateCoordinator], bool] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -49,8 +79,9 @@ class MammotionAsyncConfigSelectEntityDescription(MammotionBaseEntity, SelectEnt
 
     key: str
     options: list[str]
-    get_fn: Callable[[MammotionBaseUpdateCoordinator], int | None]
+    get_fn: Callable[[MammotionBaseUpdateCoordinator], int | str | None]
     set_fn: Callable[[MammotionBaseUpdateCoordinator, str], Awaitable[None]]
+    poll_fn: Callable[[MammotionBaseUpdateCoordinator], Awaitable[None]] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -144,6 +175,52 @@ MINI_AND_X_SERIES_CONFIG_SELECT_ENTITIES: tuple[
 )
 
 
+def _set_pattern_family(
+    coordinator: MammotionBaseUpdateCoordinator, option: str
+) -> None:
+    """Set the app-level Yuka mowing pattern family."""
+    coordinator.operation_settings.channel_mode = PATTERN_FAMILY_VALUES[option]
+
+
+def _set_pattern_variant(
+    coordinator: MammotionBaseUpdateCoordinator, option: str
+) -> None:
+    """Set the app-level Yuka path angle variant."""
+    if option in {"efficient", "default"}:
+        coordinator.operation_settings.toward_mode = (
+            PathAngleSetting.relative_angle.value
+        )
+    elif option == "random":
+        coordinator.operation_settings.toward_mode = PathAngleSetting.random_angle.value
+    elif option == "custom":
+        coordinator.operation_settings.toward_mode = (
+            PathAngleSetting.absolute_angle.value
+        )
+
+
+def _set_stripes_pattern(
+    coordinator: MammotionBaseUpdateCoordinator, option: str
+) -> None:
+    """Set the stripes variant only when stripes are active."""
+    if coordinator.operation_settings.channel_mode == STRIPES_PATTERN_VALUE:
+        _set_pattern_variant(coordinator, option)
+
+
+def _set_grid_pattern(coordinator: MammotionBaseUpdateCoordinator, option: str) -> None:
+    """Set the grid variant only when grid is active."""
+    if coordinator.operation_settings.channel_mode == GRID_PATTERN_VALUE:
+        _set_pattern_variant(coordinator, option)
+
+
+def _set_yuka_mow_order(
+    coordinator: MammotionBaseUpdateCoordinator, option: str
+) -> None:
+    """Set the app-level Yuka mow order."""
+    value = MowOrder[option].value
+    coordinator.operation_settings.border_mode = value
+    coordinator.operation_settings.job_mode = value
+
+
 SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
     MammotionConfigSelectEntityDescription(
         key="channel_mode",
@@ -174,6 +251,115 @@ SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
         set_fn=lambda coordinator, value: setattr(
             coordinator.operation_settings, "border_mode", MowOrder[value].value
         ),
+    ),
+)
+
+YUKA_SELECT_ENTITIES: tuple[MammotionConfigSelectEntityDescription, ...] = (
+    MammotionConfigSelectEntityDescription(
+        key="border_mode",
+        options=[order.name for order in MowOrder],
+        default_option=MowOrder.border_first.name,
+        set_fn=_set_yuka_mow_order,
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="mowing_laps",
+        options=LAP_OPTIONS,
+        default_option="three",
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "mowing_laps", LAP_VALUES[value]
+        ),
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="obstacle_laps",
+        options=LAP_OPTIONS,
+        default_option="none",
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "obstacle_laps", LAP_VALUES[value]
+        ),
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="bypass_mode",
+        options=OBSTACLE_OPTIONS,
+        default_option="standard",
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "ultra_wave", OBSTACLE_VALUES[value]
+        ),
+        async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="pattern_family",
+        options=PATTERN_FAMILY_OPTIONS,
+        default_option="grid",
+        set_fn=_set_pattern_family,
+        async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="stripes_pattern",
+        options=STRIPES_PATTERN_OPTIONS,
+        default_option="random",
+        set_fn=_set_stripes_pattern,
+        async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
+        available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
+        == STRIPES_PATTERN_VALUE,
+    ),
+    MammotionConfigSelectEntityDescription(
+        key="grid_pattern",
+        options=GRID_PATTERN_OPTIONS,
+        default_option="random",
+        set_fn=_set_grid_pattern,
+        async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
+        available_fn=lambda coordinator: coordinator.operation_settings.channel_mode
+        == GRID_PATTERN_VALUE,
+    ),
+)
+
+YUKA_ASYNC_SELECT_ENTITIES: tuple[MammotionAsyncConfigSelectEntityDescription, ...] = (
+    MammotionAsyncConfigSelectEntityDescription(
+        key="traversal_mode",
+        options=ROUTE_TO_DOCK_OPTIONS,
+        get_fn=lambda coordinator: yuka_value_option(
+            ROUTE_TO_DOCK_OPTIONS,
+            coordinator.data.mower_state.traversal_mode,
+            ROUTE_TO_DOCK_VALUES,
+        ),
+        set_fn=lambda coordinator, value: coordinator.async_set_traversal_mode(
+            ROUTE_TO_DOCK_VALUES[value]
+        ),
+    ),
+    MammotionAsyncConfigSelectEntityDescription(
+        key="cutter_mode",
+        options=BLADE_SPEED_OPTIONS,
+        get_fn=lambda coordinator: yuka_value_option(
+            BLADE_SPEED_OPTIONS,
+            coordinator.data.mower_state.cutter_mode,
+            BLADE_SPEED_VALUES,
+        ),
+        set_fn=lambda coordinator, value: coordinator.async_set_cutter_speed(
+            BLADE_SPEED_VALUES[value]
+        ),
+    ),
+    MammotionAsyncConfigSelectEntityDescription(
+        key="voice_volume_level",
+        options=VOICE_VOLUME_LEVEL_OPTIONS,
+        get_fn=lambda coordinator: voice_volume_option(
+            coordinator.data.mower_state.audio.volume
+        ),
+        set_fn=lambda coordinator, value: coordinator.async_set_voice_volume(
+            VOICE_VOLUME_VALUES[value]
+        ),
+    ),
+    MammotionAsyncConfigSelectEntityDescription(
+        key="wildlife_safety",
+        options=WILDLIFE_SAFETY_OPTIONS,
+        get_fn=lambda coordinator: yuka_value_option(
+            WILDLIFE_SAFETY_OPTIONS,
+            coordinator.data.mower_state.animal_protection.mode,
+            WILDLIFE_SAFETY_VALUES,
+        ),
+        set_fn=lambda coordinator, value: coordinator.async_set_wildlife_safety(
+            WILDLIFE_SAFETY_VALUES[value]
+        ),
+        poll_fn=lambda coordinator: coordinator.async_read_wildlife_safety(),
     ),
 )
 
@@ -225,16 +411,24 @@ async def async_setup_entry(
     mammotion_devices = entry.runtime_data.mowers
 
     for mower in mammotion_devices:
+        _cleanup_removed_yuka_2_selects(hass, mower.device.device_name)
         entities = []
 
-        for entity_description in SELECT_ENTITIES:
+        base_selects = (
+            YUKA_SELECT_ENTITIES
+            if is_yuka_2(mower.device.device_name)
+            else SELECT_ENTITIES
+        )
+        for entity_description in base_selects:
             entities.append(
                 MammotionConfigSelectEntity(
                     mower.reporting_coordinator, entity_description
                 )
             )
 
-        if DeviceType.is_luba_pro(mower.device.device_name):
+        if DeviceType.is_luba_pro(mower.device.device_name) and not is_yuka_2(
+            mower.device.device_name
+        ):
             for entity_description in AUDIO_SELECT_ENTITIES:
                 entities.append(
                     MammotionAsyncConfigSelectEntity(
@@ -242,32 +436,42 @@ async def async_setup_entry(
                     )
                 )
 
-        for entity_description in ASYNC_SELECT_ENTITIES:
+        async_selects = (
+            YUKA_ASYNC_SELECT_ENTITIES
+            if is_yuka_2(mower.device.device_name)
+            else ASYNC_SELECT_ENTITIES
+        )
+        for entity_description in async_selects:
             entities.append(
                 MammotionAsyncConfigSelectEntity(
                     mower.reporting_coordinator, entity_description
                 )
             )
 
-        bypass_mode_desc = MammotionConfigSelectEntityDescription(
-            key="bypass_mode",
-            options=[
-                s.name
-                for s in DetectionStrategy.for_device(
-                    mower.device.device_name,
-                    _device_firmware_version(mower.reporting_coordinator.data),
+        if not is_yuka_2(mower.device.device_name):
+            bypass_mode_desc = MammotionConfigSelectEntityDescription(
+                key="bypass_mode",
+                options=[
+                    s.name
+                    for s in DetectionStrategy.for_device(
+                        mower.device.device_name,
+                        _device_firmware_version(mower.reporting_coordinator.data),
+                    )
+                ],
+                set_fn=lambda coordinator, value: setattr(
+                    coordinator.operation_settings,
+                    "ultra_wave",
+                    DetectionStrategy[value].value,
+                ),
+                async_set_fn=(
+                    lambda coordinator: coordinator.async_modify_plan_if_mowing()
+                ),
+            )
+            entities.append(
+                MammotionConfigSelectEntity(
+                    mower.reporting_coordinator, bypass_mode_desc
                 )
-            ],
-            set_fn=lambda coordinator, value: setattr(
-                coordinator.operation_settings,
-                "ultra_wave",
-                DetectionStrategy[value].value,
-            ),
-            async_set_fn=lambda coordinator: coordinator.async_modify_plan_if_mowing(),
-        )
-        entities.append(
-            MammotionConfigSelectEntity(mower.reporting_coordinator, bypass_mode_desc)
-        )
+            )
 
         if DeviceType.is_luba1(mower.device.device_name):
             for entity_description in LUBA1_SELECT_ENTITIES:
@@ -276,7 +480,7 @@ async def async_setup_entry(
                         mower.reporting_coordinator, entity_description
                     )
                 )
-        else:
+        elif not is_yuka_mini_or_ml(mower.device.device_name):
             for entity_description in LUBA_PRO_SELECT_ENTITIES:
                 entities.append(
                     MammotionConfigSelectEntity(
@@ -284,7 +488,9 @@ async def async_setup_entry(
                     )
                 )
 
-        if DeviceType.is_mini_or_x_series(mower.device.device_name):
+        if DeviceType.is_mini_or_x_series(
+            mower.device.device_name
+        ) and not is_yuka_2(mower.device.device_name):
             for entity_description in MINI_AND_X_SERIES_CONFIG_SELECT_ENTITIES:
                 entities.append(
                     MammotionAsyncConfigSelectEntity(
@@ -299,6 +505,24 @@ async def async_setup_entry(
             MammotionSpinoSelectEntity(spino.coordinator, entity_description)
             for entity_description in SPINO_SELECT_ENTITIES
         )
+
+
+def _cleanup_removed_yuka_2_selects(hass: HomeAssistant, device_name: str) -> None:
+    """Remove select entities that are not exposed by the Yuka app controls."""
+    if not is_yuka_2(device_name):
+        return
+    registry = er.async_get(hass)
+    for key in (
+        "channel_mode",
+        "cutting_angle_mode",
+        "turning_mode",
+        "voice_gender",
+    ):
+        entity_id = registry.async_get_entity_id(
+            "select", DOMAIN, f"{device_name}_{key}"
+        )
+        if entity_id:
+            registry.async_remove(entity_id)
 
 
 # Define the select entity class with entity_category: config
@@ -321,7 +545,9 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
         self.entity_description = entity_description
         self._attr_translation_key = entity_description.key
         self._attr_options = entity_description.options
-        self._attr_current_option = entity_description.options[0]
+        self._attr_current_option = (
+            entity_description.default_option or entity_description.options[0]
+        )
         self.entity_description.set_fn(self.coordinator, self._attr_current_option)
 
     async def async_select_option(self, option: str) -> None:
@@ -330,6 +556,7 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
         self.entity_description.set_fn(self.coordinator, option)
         if self.entity_description.async_set_fn is not None:
             await self.entity_description.async_set_fn(self.coordinator)
+        self.coordinator.async_update_listeners()
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
@@ -341,6 +568,16 @@ class MammotionConfigSelectEntity(MammotionBaseEntity, SelectEntity, RestoreEnti
                 self.entity_description.set_fn(
                     self.coordinator, self._attr_current_option
                 )
+                self.coordinator.async_update_listeners()
+
+    @property
+    def available(self) -> bool:
+        """Return True when this select applies to the current Yuka settings."""
+        if self.entity_description.available_fn is None:
+            return super().available
+        return super().available and self.entity_description.available_fn(
+            self.coordinator
+        )
 
 
 # Define the select entity class with entity_category: config
@@ -368,9 +605,15 @@ class MammotionAsyncConfigSelectEntity(
         self._attr_current_option = self._resolve_option()
 
     def _resolve_option(self) -> str:
-        """Return the current option, falling back to the first if the index is out of range."""
+        """Return the current option, falling back to the first option."""
         if callable(self.entity_description.get_fn):
-            idx = self.entity_description.get_fn(self.coordinator)
+            value = self.entity_description.get_fn(self.coordinator)
+            if isinstance(value, str) and value in self._attr_options:
+                return value
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                return self._attr_options[0]
             if 0 <= idx < len(self._attr_options):
                 return self._attr_options[idx]
         return self._attr_options[0]
@@ -396,10 +639,10 @@ class MammotionAsyncConfigSelectEntity(
 
     async def async_update(self) -> None:
         """Update entity state from coordinator."""
+        if self.entity_description.poll_fn is not None:
+            await self.entity_description.poll_fn(self.coordinator)
         if callable(self.entity_description.get_fn):
-            self._attr_current_option = self._attr_options[
-                self.entity_description.get_fn(self.coordinator)
-            ]
+            self._attr_current_option = self._resolve_option()
         self.async_write_ha_state()
 
 

--- a/custom_components/mammotion/sensor.py
+++ b/custom_components/mammotion/sensor.py
@@ -59,6 +59,7 @@ from .entity import (
     MammotionBaseRTKEntity,
     MammotionBaseSpinoEntity,
 )
+from .yuka import is_yuka_2
 
 
 class MowerDataFormatter:
@@ -538,6 +539,14 @@ async def async_setup_entry(
 
     entities = []
     for mower in mammotion_mowers:
+        yuka2 = is_yuka_2(mower.device.device_name) or is_yuka_2(
+            mower.reporting_coordinator.unique_name
+        )
+        if yuka2:
+            _cleanup_removed_yuka_2_sensors(
+                hass, mower.reporting_coordinator.unique_name
+            )
+
         if not DeviceType.is_yuka(mower.device.device_name):
             entities.extend(
                 MammotionSensorEntity(mower.reporting_coordinator, description)
@@ -545,9 +554,18 @@ async def async_setup_entry(
             )
 
         if DeviceType.is_luba_pro(mower.device.device_name):
+            luba_2_yuka_types = (
+                tuple(
+                    description
+                    for description in LUBA_2_YUKA_ONLY_TYPES
+                    if description.key != "camera_brightness"
+                )
+                if yuka2
+                else LUBA_2_YUKA_ONLY_TYPES
+            )
             entities.extend(
                 MammotionSensorEntity(mower.reporting_coordinator, description)
-                for description in LUBA_2_YUKA_ONLY_TYPES
+                for description in luba_2_yuka_types
             )
             if not DeviceType.is_yuka_mini(mower.device.device_name):
                 entities.extend(
@@ -555,9 +573,19 @@ async def async_setup_entry(
                     for description in MINI_SERIES_EXCLUDED_TYPES
                 )
 
+        sensor_types = (
+            tuple(
+                description
+                for description in SENSOR_TYPES
+                if description.key != "non_work_hours"
+            )
+            if yuka2
+            else SENSOR_TYPES
+        )
+
         entities.extend(
             MammotionSensorEntity(mower.reporting_coordinator, description)
-            for description in SENSOR_TYPES
+            for description in sensor_types
         )
         entities.extend(
             MammotionWorkSensorEntity(mower.reporting_coordinator, description)
@@ -600,6 +628,22 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities)
+
+
+def _cleanup_removed_yuka_2_sensors(hass: HomeAssistant, unique_name: str) -> None:
+    """Remove sensor entities that are not exposed by the Yuka app controls."""
+    registry = er.async_get(hass)
+    removed_unique_ids = {
+        f"{unique_name}_{key}"
+        for key in ("camera_brightness", "non_work_hours", "route_settings")
+    }
+    for entry in list(registry.entities.values()):
+        if (
+            entry.domain == SENSOR_DOMAIN
+            and entry.platform == DOMAIN
+            and entry.unique_id in removed_unique_ids
+        ):
+            registry.async_remove(entry.entity_id)
 
 
 class MammotionSensorEntity(MammotionBaseEntity, SensorEntity):

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -409,6 +409,7 @@
       "wildlife_safety": {
         "name": "Wildlife safety",
         "state": {
+          "off": "Off",
           "low_speed_mowing": "Low-speed mowing",
           "stop_mowing": "Stop mowing"
         }

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -332,7 +332,7 @@
         "name": "Mow Order",
         "state": {
           "border_first": "Perimeter first",
-          "grid_first": "ZigZag / Chessboard first"
+          "grid_first": "Interior first"
         }
       },
       "bypass_mode": {
@@ -582,7 +582,7 @@
         },
         "border_mode": {
           "name": "Mow order",
-          "description": "Mowing path order (Perimeter first or grid first)."
+          "description": "Mowing path order (perimeter first or interior first)."
         },
         "job_version": {
           "name": "Job version",

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -270,6 +270,9 @@
       "rain_detection": {
         "name": "Rain detection (mower) On/Off"
       },
+      "auto_lighting": {
+        "name": "Auto lighting"
+      },
       "side_led": {
         "name": "Side LED on/off"
       },
@@ -335,6 +338,8 @@
       "bypass_mode": {
         "name": "Obstacle detection",
         "state": {
+          "off": "Off",
+          "standard": "Standard",
           "direct_touch": "Off",
           "slow_touch": "Slow touch",
           "less_touch": "Less touch",
@@ -348,6 +353,64 @@
           "relative_angle": "Optimal",
           "absolute_angle": "North",
           "random_angle": "Random"
+        }
+      },
+      "pattern_family": {
+        "name": "Mowing pattern",
+        "state": {
+          "perimeter_only": "Perimeter only",
+          "stripes": "Stripes",
+          "grid": "Grid"
+        }
+      },
+      "stripes_pattern": {
+        "name": "Stripes pattern",
+        "state": {
+          "efficient": "Efficient",
+          "random": "Random",
+          "custom": "Custom"
+        }
+      },
+      "grid_pattern": {
+        "name": "Grid pattern",
+        "state": {
+          "default": "Default",
+          "random": "Random",
+          "custom": "Custom"
+        }
+      },
+      "traversal_mode": {
+        "name": "Route to dock",
+        "state": {
+          "direct": "Direct",
+          "follow_perimeter": "Follow the perimeter"
+        }
+      },
+      "cutter_mode": {
+        "name": "Blade speed",
+        "state": {
+          "low": "Low",
+          "high": "High",
+          "normal": "Medium",
+          "slow": "Slow",
+          "fast": "Fast"
+        }
+      },
+      "voice_volume_level": {
+        "name": "Voice volume",
+        "state": {
+          "one": "1",
+          "two": "2",
+          "three": "3",
+          "four": "4",
+          "five": "5"
+        }
+      },
+      "wildlife_safety": {
+        "name": "Wildlife safety",
+        "state": {
+          "low_speed_mowing": "Low-speed mowing",
+          "stop_mowing": "Stop mowing"
         }
       },
       "voice_gender": {
@@ -407,6 +470,9 @@
       "path_spacing": {
         "name": "Path spacing"
       },
+      "pattern_angle": {
+        "name": "Pattern angle"
+      },
       "dumping_interval": {
         "name": "Dumping frequency"
       },
@@ -425,6 +491,11 @@
     },
     "device_tracker": {
       "name": "Device Tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -571,12 +571,10 @@ class MammotionConfigAreaSwitchEntity(MammotionBaseEntity, SwitchEntity, Restore
     async def async_update(self) -> None:
         """Update the entity state."""
         self._attr_is_on = self._area in self.coordinator.operation_settings.areas
-        area_keys: set[int] = {
-            int(k)
-            for k in self.coordinator.data.map.area.keys()
-            if str(k).lstrip("-").isdigit()
-        }
-        if self._area not in area_keys:
+        known_area_hashes = _known_area_hashes(self.coordinator)
+        if self._area not in known_area_hashes and _area_names_loaded(
+            self.coordinator
+        ):
             await self.async_remove()
             return
         self.async_write_ha_state()
@@ -598,16 +596,22 @@ def async_add_area_entities(
     if coordinator.data is None:
         return
 
-    computed = coordinator.data.map.computed_areas
+    computed = coordinator.data.map.computed_areas or []
     map_area_hashes: set[int] = {
         int(k) for k in coordinator.data.map.area.keys() if str(k).lstrip("-").isdigit()
     }
-    area_names_by_hash: dict[int, str] = {
-        area.hash: area.name
-        for area in computed
-        if not map_area_hashes or area.hash in map_area_hashes
-    }
-    area_names_by_hash.update(_active_named_areas(coordinator, map_area_hashes))
+    area_names_by_hash = _active_named_areas(coordinator, map_area_hashes)
+    area_names = {name.lower() for name in area_names_by_hash.values()}
+    for area in computed:
+        area_name = str(getattr(area, "name", "") or "").strip()
+        if not area_name or _is_generic_area_name(area_name, area.hash):
+            continue
+        if map_area_hashes and area.hash not in map_area_hashes:
+            if area_name.lower() in area_names:
+                continue
+        area_names_by_hash[area.hash] = area_name
+        area_names.add(area_name.lower())
+    area_names_by_hash.update(_fallback_named_areas(coordinator, area_names_by_hash))
     all_current_areas = set(area_names_by_hash)
     if map_area_hashes and not all_current_areas:
         return
@@ -615,14 +619,13 @@ def async_add_area_entities(
     # Trigger re-fetch when the device hasn't yet sent names for all areas.
     # Luba 1 never provides area_name, so skip for it.
     if not DeviceType.is_luba1(coordinator.device_name):
-        area_name_hashes: set[int] = {
-            a.hash for a in coordinator.data.map.area_name if a.hash in map_area_hashes
-        }
-        if map_area_hashes - area_name_hashes:
+        named_map_area_hashes = set(area_names_by_hash) & map_area_hashes
+        if map_area_hashes - named_map_area_hashes:
             coordinator.hass.async_create_task(coordinator.async_get_area_list())
 
     # Startup registry cleanup: remove stale entries from previous sessions.
-    if map_area_hashes and (all_current_areas - added_areas):
+    area_names_loaded = _area_names_loaded(coordinator)
+    if map_area_hashes and area_names_loaded and (all_current_areas - added_areas):
         _async_clean_stale_area_registry_entries(
             coordinator, all_current_areas, area_names_by_hash
         )
@@ -699,7 +702,7 @@ def async_add_area_entities(
 
     # Guard: only remove when map.area is non-empty — an empty map is a transient
     # refresh state and must not wipe the entity registry.
-    if map_area_hashes:
+    if map_area_hashes and area_names_loaded:
         old_areas = added_areas - all_current_areas
         if old_areas:
             async_remove_entities(coordinator, old_areas)
@@ -729,6 +732,20 @@ def _active_named_areas(
         return {}
 
     named_areas: dict[int, str] = {}
+    for area_hash, area_data in coordinator.data.map.area.items():
+        try:
+            area_id = int(area_hash)
+        except (TypeError, ValueError):
+            continue
+        if area_id not in map_area_hashes:
+            continue
+        for frame in getattr(area_data, "data", []) or []:
+            name_time = getattr(frame, "name_time", None)
+            name = str(getattr(name_time, "name", "") or "").strip()
+            if name and not _is_generic_area_name(name, area_id):
+                named_areas[area_id] = name
+                break
+
     generated_geojson = getattr(coordinator.data.map, "generated_geojson", None) or {}
     for feature in generated_geojson.get("features", []):
         properties = feature.get("properties", {})
@@ -756,6 +773,56 @@ def _active_named_areas(
             named_areas[area_id] = name
 
     return named_areas
+
+
+def _fallback_named_areas(
+    coordinator: MammotionReportUpdateCoordinator, current_areas: dict[int, str]
+) -> dict[int, str]:
+    """Return named areas that are known but not present in the current map payload."""
+    current_names = {name.lower() for name in current_areas.values()}
+    named_areas: dict[int, str] = {}
+
+    for area in coordinator.data.map.area_name:
+        try:
+            area_id = int(area.hash)
+        except (TypeError, ValueError):
+            continue
+        name = str(getattr(area, "name", "") or "").strip()
+        if not name or _is_generic_area_name(name, area_id):
+            continue
+        if name.lower() in current_names:
+            continue
+        named_areas[area_id] = name
+        current_names.add(name.lower())
+
+    return named_areas
+
+
+def _known_area_hashes(coordinator: MammotionBaseUpdateCoordinator) -> set[int]:
+    """Return area hashes that the mower currently advertises as selectable."""
+    mower_map = getattr(coordinator.data, "map", None)
+    if mower_map is None:
+        return set()
+
+    area_hashes: set[int] = {
+        int(k) for k in mower_map.area.keys() if str(k).lstrip("-").isdigit()
+    }
+    for area in mower_map.area_name:
+        try:
+            area_id = int(area.hash)
+        except (TypeError, ValueError):
+            continue
+        name = str(getattr(area, "name", "") or "").strip()
+        if name and not _is_generic_area_name(name, area_id):
+            area_hashes.add(area_id)
+
+    return area_hashes
+
+
+def _area_names_loaded(coordinator: MammotionBaseUpdateCoordinator) -> bool:
+    """Return True when the mower has supplied its named area list."""
+    mower_map = getattr(coordinator.data, "map", None)
+    return bool(getattr(mower_map, "area_name", None))
 
 
 def _is_generic_area_name(name: str, area_id: int) -> bool:

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import slugify
 from pymammotion.data.model.device import PoolCleanerDevice
 from pymammotion.data.model.pool_state import SpinoToggle
 from pymammotion.utility.device_type import DeviceType
@@ -558,23 +559,34 @@ def async_add_area_entities(
     if coordinator.data is None:
         return
 
-    switch_entities: list[MammotionConfigAreaSwitchEntity] = []
     computed = coordinator.data.map.computed_areas
-    all_current_areas = {a.hash for a in computed}
     map_area_hashes: set[int] = {
         int(k) for k in coordinator.data.map.area.keys() if str(k).lstrip("-").isdigit()
     }
+    area_names_by_hash: dict[int, str] = {
+        area.hash: area.name
+        for area in computed
+        if not map_area_hashes or area.hash in map_area_hashes
+    }
+    area_names_by_hash.update(_active_named_areas(coordinator, map_area_hashes))
+    all_current_areas = set(area_names_by_hash)
+    if map_area_hashes and not all_current_areas:
+        return
 
     # Trigger re-fetch when the device hasn't yet sent names for all areas.
     # Luba 1 never provides area_name, so skip for it.
     if not DeviceType.is_luba1(coordinator.device_name):
-        area_name_hashes: set[int] = {a.hash for a in coordinator.data.map.area_name}
+        area_name_hashes: set[int] = {
+            a.hash for a in coordinator.data.map.area_name if a.hash in map_area_hashes
+        }
         if map_area_hashes - area_name_hashes:
             coordinator.hass.async_create_task(coordinator.async_get_area_list())
 
     # Startup registry cleanup: remove stale entries from previous sessions.
     if map_area_hashes and (all_current_areas - added_areas):
-        _async_clean_stale_area_registry_entries(coordinator, all_current_areas)
+        _async_clean_stale_area_registry_entries(
+            coordinator, all_current_areas, area_names_by_hash
+        )
 
     # Pre-clear auto-generated names for areas about to be removed so that
     # surviving areas can be renumbered into the freed slots without collision.
@@ -600,9 +612,10 @@ def async_add_area_entities(
         e._area: (name, e) for name, e in area_entities_by_name.items()
     }
 
-    for entry in computed:
-        area_id = entry.hash
-        new_name = entry.name
+    switch_entities: list[MammotionConfigAreaSwitchEntity] = []
+    for area_id, new_name in sorted(
+        area_names_by_hash.items(), key=lambda item: item[1].lower()
+    ):
 
         if area_id in added_areas:
             # Already tracked — update name unless we'd overwrite a real device name
@@ -633,7 +646,7 @@ def async_add_area_entities(
 
         # Missing area — add a new entity with the name supplied by computed_areas.
         base_area_switch_entity = MammotionConfigAreaSwitchEntityDescription(
-            key=f"{area_id}",
+            key=_area_entity_key(area_id, new_name),
             translation_key="area",
             translation_placeholders={"name": new_name},
             area=area_id,
@@ -662,29 +675,89 @@ def async_add_area_entities(
         async_add_entities(switch_entities)
 
 
+def _area_entity_key(area_id: int, name: str) -> str:
+    """Return a stable key for named areas and hash key for unnamed areas."""
+    if _is_generic_area_name(name, area_id):
+        return f"{area_id}"
+    return f"area_{slugify(name)}"
+
+
+def _active_named_areas(
+    coordinator: MammotionReportUpdateCoordinator, map_area_hashes: set[int]
+) -> dict[int, str]:
+    """Return real area names keyed by active mower area hash."""
+    if not map_area_hashes:
+        return {}
+
+    named_areas: dict[int, str] = {}
+    generated_geojson = getattr(coordinator.data.map, "generated_geojson", None) or {}
+    for feature in generated_geojson.get("features", []):
+        properties = feature.get("properties", {})
+        if properties.get("type_name") != "area":
+            continue
+        try:
+            area_id = int(properties.get("hash"))
+        except (TypeError, ValueError):
+            continue
+        if area_id not in map_area_hashes:
+            continue
+        name = str(properties.get("Name") or properties.get("title") or "").strip()
+        if name and not _is_generic_area_name(name, area_id):
+            named_areas[area_id] = name
+
+    for area in coordinator.data.map.area_name:
+        try:
+            area_id = int(area.hash)
+        except (TypeError, ValueError):
+            continue
+        if area_id not in map_area_hashes:
+            continue
+        name = str(getattr(area, "name", "") or "").strip()
+        if name and not _is_generic_area_name(name, area_id):
+            named_areas[area_id] = name
+
+    return named_areas
+
+
+def _is_generic_area_name(name: str, area_id: int) -> bool:
+    """Return True for placeholder area names reported by Mammotion firmware."""
+    normalized = name.strip().lower()
+    return (
+        normalized in {"path", f"area {area_id}", str(area_id)}
+        or bool(_PYMAMMOTION_AUTO_NAME.match(normalized))
+    )
+
+
 def _async_clean_stale_area_registry_entries(
     coordinator: MammotionReportUpdateCoordinator,
     all_current_areas: set[int],
+    area_names_by_hash: dict[int, str],
 ) -> None:
     """Remove area entity registry entries whose hashes are no longer on the device.
 
-    Area entity unique_ids follow ``{unique_name}_{hash}`` where the suffix is
-    the numeric area hash.  Any entry whose hash is absent from
-    ``all_current_areas`` is removed so it cannot appear as a ghost duplicate
-    alongside the replacement entity.
+    Older area entity unique_ids used the area hash directly. Named areas now use
+    a stable name key, so both old hash entries and old name entries are cleaned.
     """
     registry = er.async_get(coordinator.hass)
     prefix = f"{coordinator.unique_name}_"
+    active_unique_ids = {
+        f"{coordinator.unique_name}_{_area_entity_key(area_id, name)}"
+        for area_id, name in area_names_by_hash.items()
+    }
+    area_entity_id_prefix = f"switch.{slugify(coordinator.device_name)}_area_"
 
     for entry in list(registry.entities.values()):
         if entry.domain != SWITCH_DOMAIN or entry.platform != DOMAIN:
             continue
         if not entry.unique_id.startswith(prefix):
             continue
+        if entry.unique_id in active_unique_ids:
+            continue
         suffix = entry.unique_id[len(prefix) :]
-        if not suffix.lstrip("-").isdigit():
-            continue  # non-numeric suffix → not an area entity (e.g. "is_mow")
-        if int(suffix) not in all_current_areas:
+        if suffix.lstrip("-").isdigit() and int(suffix) not in all_current_areas:
+            registry.async_remove(entry.entity_id)
+            continue
+        if entry.entity_id.startswith(area_entity_id_prefix):
             registry.async_remove(entry.entity_id)
 
 

--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -28,6 +28,7 @@ from .coordinator import (
     MammotionSpinoCoordinator,
 )
 from .entity import MammotionBaseEntity, MammotionBaseSpinoEntity
+from .yuka import is_yuka_2
 
 # Matches pymammotion's auto-generated fallback names ("area 1", "area 2", …).
 # These carry no user intent and must be treated the same as empty names.
@@ -145,6 +146,35 @@ MINI_AND_X_SERIES_CONFIG_SWITCH_ENTITIES: tuple[
     ),
 )
 
+YUKA_SWITCH_ENTITIES: tuple[MammotionAsyncSwitchEntityDescription, ...] = (
+    MammotionAsyncSwitchEntityDescription(
+        key="rain_detection",
+        is_on_func=lambda coordinator: coordinator.data.mower_state.rain_detection,
+        set_fn=lambda coordinator, value: coordinator.async_set_rain_detection(value),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    MammotionAsyncSwitchEntityDescription(
+        key="auto_lighting",
+        is_on_func=lambda coordinator: coordinator.data.mower_state.lamp_info.night_light,
+        set_fn=lambda coordinator, value: coordinator.async_set_night_light(value),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    MammotionAsyncSwitchEntityDescription(
+        key="side_led",
+        is_on_func=lambda coordinator: bool(
+            coordinator.data.mower_state.side_led.operate
+        ),
+        set_fn=lambda coordinator, value: coordinator.async_set_sidelight(int(value)),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    MammotionAsyncSwitchEntityDescription(
+        key="voice_on_off",
+        is_on_func=lambda coordinator: coordinator.data.mower_state.audio.volume > 0,
+        set_fn=lambda coordinator, value: coordinator.async_set_voice_on_off(value),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
 AUDIO_SWITCH_ENTITIES: tuple[MammotionAsyncSwitchEntityDescription, ...] = (
     MammotionAsyncSwitchEntityDescription(
         key="voice_on_off",
@@ -157,8 +187,9 @@ AUDIO_SWITCH_ENTITIES: tuple[MammotionAsyncSwitchEntityDescription, ...] = (
 SWITCH_ENTITIES: tuple[MammotionAsyncSwitchEntityDescription, ...] = (
     MammotionAsyncSwitchEntityDescription(
         key="side_led",
-        is_on_func=lambda coordinator: coordinator.data.mower_state.side_led.enable
-        == 0,
+        is_on_func=lambda coordinator: bool(
+            coordinator.data.mower_state.side_led.operate
+        ),
         set_fn=lambda coordinator, value: coordinator.async_set_sidelight(int(value)),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -222,6 +253,7 @@ async def async_setup_entry(
     mammotion_devices = entry.runtime_data.mowers
 
     for mower in mammotion_devices:
+        _cleanup_removed_yuka_2_switches(hass, mower.device.device_name)
         added_areas: set[int] = set()
         area_entities_by_name: dict[str, MammotionConfigAreaSwitchEntity] = {}
         coordinator = mower.reporting_coordinator
@@ -238,6 +270,13 @@ async def async_setup_entry(
         coordinator.subscribe_map_updated(update_areas)
 
         entities = []
+        if is_yuka_2(mower.device.device_name):
+            async_add_entities(
+                MammotionSwitchEntity(coordinator, entity_description)
+                for entity_description in YUKA_SWITCH_ENTITIES
+            )
+            continue
+
         for entity_description in SWITCH_ENTITIES:
             entity = MammotionSwitchEntity(coordinator, entity_description)
             entities.append(entity)
@@ -759,6 +798,34 @@ def _async_clean_stale_area_registry_entries(
             continue
         if entry.entity_id.startswith(area_entity_id_prefix):
             registry.async_remove(entry.entity_id)
+
+
+def _cleanup_removed_yuka_2_switches(
+    hass: HomeAssistant,
+    device_name: str,
+) -> None:
+    """Remove switch entities that are not exposed by the Yuka app controls."""
+    if not is_yuka_2(device_name):
+        return
+    registry = er.async_get(hass)
+    for key in (
+        "manual_light",
+        "night_light",
+        "is_mow",
+        "is_dump",
+        "is_edge",
+        "rain_tactics",
+        "schedule_updates",
+        "bluetooth_enabled",
+        "cloud_enabled",
+    ):
+        entity_id = registry.async_get_entity_id(
+            SWITCH_DOMAIN,
+            DOMAIN,
+            f"{device_name}_{key}",
+        )
+        if entity_id:
+            registry.async_remove(entity_id)
 
 
 def async_remove_entities(

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -349,6 +349,9 @@
       "rain_detection": {
         "name": "Rain detection (Mower) On/Off"
       },
+      "auto_lighting": {
+        "name": "Auto lighting"
+      },
       "side_led": {
         "name": "Side LED on/off"
       },
@@ -426,6 +429,8 @@
       "bypass_mode": {
         "name": "Obstacle detection",
         "state": {
+          "off": "Off",
+          "standard": "Standard",
           "direct_touch": "Off",
           "slow_touch": "Slow touch",
           "less_touch": "Less touch",
@@ -442,7 +447,7 @@
         }
       },
       "traversal_mode": {
-        "name": "Traversal Mode",
+        "name": "Route to dock",
         "state": {
           "direct": "Direct",
           "follow_perimeter": "Follow the perimeter"
@@ -456,19 +461,55 @@
         }
       },
       "wildlife_safety": {
-        "name": "Wildlife Safety",
+        "name": "Wildlife safety",
         "state": {
           "off": "Off",
-          "stop_mowing": "Stop Mowing",
-          "low_speed_mowing": "Low-Speed Mowing"
+          "stop_mowing": "Stop mowing",
+          "low_speed_mowing": "Low-speed mowing"
         }
       },
       "cutter_mode": {
-        "name": "Cutter Speed",
+        "name": "Blade speed",
         "state": {
+          "low": "Low",
+          "high": "High",
           "normal": "Medium",
           "slow": "Slow",
           "fast": "Fast"
+        }
+      },
+      "pattern_family": {
+        "name": "Mowing pattern",
+        "state": {
+          "perimeter_only": "Perimeter only",
+          "stripes": "Stripes",
+          "grid": "Grid"
+        }
+      },
+      "stripes_pattern": {
+        "name": "Stripes pattern",
+        "state": {
+          "efficient": "Efficient",
+          "random": "Random",
+          "custom": "Custom"
+        }
+      },
+      "grid_pattern": {
+        "name": "Grid pattern",
+        "state": {
+          "default": "Default",
+          "random": "Random",
+          "custom": "Custom"
+        }
+      },
+      "voice_volume_level": {
+        "name": "Voice volume",
+        "state": {
+          "one": "1",
+          "two": "2",
+          "three": "3",
+          "four": "4",
+          "five": "5"
         }
       },
       "voice_gender": {
@@ -528,6 +569,9 @@
       "path_spacing": {
         "name": "Path spacing"
       },
+      "pattern_angle": {
+        "name": "Pattern angle"
+      },
       "dumping_interval": {
         "name": "Dumping frequency"
       },
@@ -546,6 +590,11 @@
     },
     "device_tracker": {
       "name": "Device tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -423,7 +423,7 @@
         "name": "Mow Order",
         "state": {
           "border_first": "Perimeter first",
-          "grid_first": "ZigZag / Chessboard first"
+          "grid_first": "Interior first"
         }
       },
       "bypass_mode": {
@@ -684,7 +684,7 @@
         },
         "border_mode": {
           "name": "Mow order",
-          "description": "Mowing path order (Perimeter first or grid first)."
+          "description": "Mowing path order (perimeter first or interior first)."
         },
         "job_version": {
           "name": "Job version",

--- a/custom_components/mammotion/yuka.py
+++ b/custom_components/mammotion/yuka.py
@@ -16,7 +16,7 @@ VOICE_VOLUME_LEVEL_OPTIONS = ["one", "two", "three", "four", "five"]
 PATTERN_FAMILY_OPTIONS = ["perimeter_only", "stripes", "grid"]
 STRIPES_PATTERN_OPTIONS = ["efficient", "random", "custom"]
 GRID_PATTERN_OPTIONS = ["default", "random", "custom"]
-WILDLIFE_SAFETY_OPTIONS = ["low_speed_mowing", "stop_mowing"]
+WILDLIFE_SAFETY_OPTIONS = ["off", "low_speed_mowing", "stop_mowing"]
 
 PATTERN_FAMILY_VALUES = {"perimeter_only": 3, "stripes": 0, "grid": 1}
 STRIPES_PATTERN_VALUE = PATTERN_FAMILY_VALUES["stripes"]
@@ -26,7 +26,7 @@ OBSTACLE_VALUES = {"off": 0, "standard": 10, "sensitive": 11}
 BLADE_SPEED_VALUES = {"low": 1, "high": 2}
 ROUTE_TO_DOCK_VALUES = {"direct": 0, "follow_perimeter": 1}
 VOICE_VOLUME_VALUES = {"one": 20, "two": 40, "three": 60, "four": 80, "five": 100}
-WILDLIFE_SAFETY_VALUES = {"low_speed_mowing": 2, "stop_mowing": 1}
+WILDLIFE_SAFETY_VALUES = {"off": 0, "low_speed_mowing": 2, "stop_mowing": 1}
 
 
 def is_yuka_2(device_name: str) -> bool:

--- a/custom_components/mammotion/yuka.py
+++ b/custom_components/mammotion/yuka.py
@@ -1,0 +1,72 @@
+"""Yuka model helpers and app-facing option mappings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pymammotion.utility.device_type import DeviceType
+
+YUKA_ML_PREFIX = "Yuka-ML"
+
+LAP_OPTIONS = ["none", "one", "two", "three"]
+OBSTACLE_OPTIONS = ["off", "standard", "sensitive"]
+BLADE_SPEED_OPTIONS = ["low", "high"]
+ROUTE_TO_DOCK_OPTIONS = ["direct", "follow_perimeter"]
+VOICE_VOLUME_LEVEL_OPTIONS = ["one", "two", "three", "four", "five"]
+PATTERN_FAMILY_OPTIONS = ["perimeter_only", "stripes", "grid"]
+STRIPES_PATTERN_OPTIONS = ["efficient", "random", "custom"]
+GRID_PATTERN_OPTIONS = ["default", "random", "custom"]
+WILDLIFE_SAFETY_OPTIONS = ["low_speed_mowing", "stop_mowing"]
+
+PATTERN_FAMILY_VALUES = {"perimeter_only": 3, "stripes": 0, "grid": 1}
+STRIPES_PATTERN_VALUE = PATTERN_FAMILY_VALUES["stripes"]
+GRID_PATTERN_VALUE = PATTERN_FAMILY_VALUES["grid"]
+LAP_VALUES = {"none": 0, "one": 1, "two": 2, "three": 3}
+OBSTACLE_VALUES = {"off": 0, "standard": 10, "sensitive": 11}
+BLADE_SPEED_VALUES = {"low": 1, "high": 2}
+ROUTE_TO_DOCK_VALUES = {"direct": 0, "follow_perimeter": 1}
+VOICE_VOLUME_VALUES = {"one": 20, "two": 40, "three": 60, "four": 80, "five": 100}
+WILDLIFE_SAFETY_VALUES = {"low_speed_mowing": 2, "stop_mowing": 1}
+
+
+def is_yuka_2(device_name: str) -> bool:
+    """Return True for Yuka 2 / Yuka ML devices."""
+    is_yuka_ml = getattr(DeviceType, "is_yuka_ml", None)
+    return device_name.startswith(YUKA_ML_PREFIX) or (
+        callable(is_yuka_ml) and is_yuka_ml(device_name)
+    )
+
+
+def is_yuka_mini_or_ml(device_name: str) -> bool:
+    """Return True for Yuka models that do not expose legacy Yuka sweeper features."""
+    return is_yuka_2(device_name) or DeviceType.is_yuka_mini(device_name)
+
+
+def yuka_value_option(options: list[str], value: Any, values: dict[str, int]) -> str:
+    """Map a numeric device value back to an exposed option."""
+    try:
+        numeric_value = int(value)
+    except (TypeError, ValueError):
+        return options[0]
+
+    for option, option_value in values.items():
+        if option_value == numeric_value and option in options:
+            return option
+    return options[0]
+
+
+def voice_volume_option(volume: Any) -> str:
+    """Map a 0-100 voice volume to one of the five app levels."""
+    try:
+        numeric_volume = int(volume)
+    except (TypeError, ValueError):
+        numeric_volume = 0
+    if numeric_volume <= 20:
+        return "one"
+    if numeric_volume <= 40:
+        return "two"
+    if numeric_volume <= 60:
+        return "three"
+    if numeric_volume <= 80:
+        return "four"
+    return "five"


### PR DESCRIPTION
Been running this locally against a Yuka 2.

This does a few things:

- keeps cloud auth around, but prefers BLE for control
- trims the Yuka 2 entities to the stuff the app actually exposes
- adds usable area selects and app-style task controls
- renders the mower map as an image, with labels and location trail
- makes route start/readback fail loudly instead of silently doing nothing
- treats `CHARGE_ON` as docked, and backs off the noisy dynamics-line polling

Tested:

- `ha core check`
- Python compile for the integration files
- plan-only routes for grid, stripes, and perimeter-only
- short live starts, pause/resume, cancel, and dock on my Yuka 2

Notes:

- camera/stream work is intentionally not in here; I couldn't get it reliable enough
- this is focused on Yuka 2 / ML-style controls, not older mower models
