### PR TITLE
fix: persist Bluetooth/Cloud transport switches across reload & restart

### DIFF
--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
@@ -46,6 +46,12 @@ class MammotionAsyncSwitchEntityDescription(MammotionSwitchEntityDescription):
 
     is_on_func: Callable[[MammotionBaseUpdateCoordinator], bool] | None = None
     set_fn: Callable[[MammotionBaseUpdateCoordinator, bool], Awaitable[None]]
+    # When True, the HA-restored state is re-applied to the coordinator on
+    # startup. Use only for switches whose source of truth is integration-local
+    # (e.g. transport selection) and therefore has nothing on the device/cloud to
+    # read back. Device-state switches must leave this False so they sync from the
+    # device report instead.
+    restore_and_apply: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -193,12 +199,14 @@ CONNECTIVITY_SWITCH_ENTITIES: tuple[MammotionAsyncSwitchEntityDescription, ...] 
             value
         ),
         entity_category=EntityCategory.CONFIG,
+        restore_and_apply=True,
     ),
     MammotionAsyncSwitchEntityDescription(
         key="cloud_enabled",
         is_on_func=lambda coordinator: coordinator.cloud_enabled,
         set_fn=lambda coordinator, value: coordinator.async_set_cloud_enabled(value),
         entity_category=EntityCategory.CONFIG,
+        restore_and_apply=True,
     ),
 )
 
@@ -342,6 +350,17 @@ class MammotionSwitchEntity(MammotionBaseEntity, SwitchEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
         if not (last_state := await self.async_get_last_state()):
+            return
+        if self.entity_description.restore_and_apply:
+            # Integration-local switches (transport selection) have no device or
+            # cloud value to read on startup, so the coordinator would otherwise
+            # reset to its in-memory default. Re-apply the restored state so the
+            # user's choice survives reloads/restarts. Only act on a concrete
+            # on/off; ignore unavailable/unknown so a stale state can't silently
+            # flip the transport.
+            if last_state.state in (STATE_ON, STATE_OFF):
+                self._attr_is_on = last_state.state == STATE_ON
+                await self.entity_description.set_fn(self.coordinator, self._attr_is_on)
             return
         self._attr_is_on = last_state.state == STATE_ON
 


### PR DESCRIPTION
## Summary

The **Bluetooth** and **Cloud** transport switches (`switch.<device>_bluetooth`, `switch.<device>_cloud`) don't survive an integration reload or Home Assistant restart. If a user turns Bluetooth **off**, it silently comes back **on** on the next reload/restart, and the integration resumes attempting BLE connections.

## Symptom

Turn the Bluetooth switch off → reload the integration (or restart HA) → the switch is back on and BLE is re-enabled. For a cloud-capable device whose BLE never bonds (e.g. via an ESP32 Bluetooth proxy), this means HA keeps periodically grabbing the mower's single BLE link, which can lock the official Mammotion app out of Bluetooth at random.

## Root cause

`MammotionSwitchEntity.async_added_to_hass` restores the **displayed** state from `RestoreEntity`, but never re-applies it to the coordinator:

```python
self._attr_is_on = last_state.state == STATE_ON   # display only
```

So on reload the coordinator's `_bluetooth_enabled` / `_cloud_enabled` flags re-initialise to their hardcoded `True` default, and the first `_handle_coordinator_update` recomputes the icon from that flag — flipping the switch back **on**. The restored "off" is cosmetic and short-lived.

The integration already has the correct pattern one class over: `MammotionConfigSwitchEntity.async_added_to_hass` restores **and** re-applies via `set_fn`. The async switch class just doesn't do the re-apply.

## Why only these two switches

`bluetooth_enabled` / `cloud_enabled` are **integration-local transport selection** — `set_prefer_ble` is a local flag and `connect_transport` / `disconnect_transport` only open/close this client's own connection; nothing is sent to the robot or cloud. So unlike device-state switches (`blade_status`, `manual_light`, `rain_detection`, …), they have **no upstream source of truth** to read on startup and must persist locally. Device-state switches must *not* be re-applied on boot (e.g. re-applying `blade_status` would command the blades on every restart), so the fix is opt-in and scoped to the two transport switches.

## Fix

- Add an opt-in `restore_and_apply: bool = False` to `MammotionAsyncSwitchEntityDescription`.
- Set it `True` on `bluetooth_enabled` and `cloud_enabled` only.
- In `MammotionSwitchEntity.async_added_to_hass`, when the flag is set, re-apply the restored state via `set_fn` (mirroring `MammotionConfigSwitchEntity`). Guarded to a concrete `on`/`off` so a stale `unavailable`/`unknown` can't silently flip the transport.

Device-state switches keep `restore_and_apply=False` and continue syncing from the device report — behaviour unchanged. One file changed (`custom_components/mammotion/switch.py`), `+20 / −1`.

## Reproduction / verification

Reproduced and verified live against a Yuka Mini 2 (cloud account), twice:

1. Set `switch.<device>_bluetooth` → off (confirmed off).
2. `homeassistant.reload_config_entry`.
3. The switch is briefly restored to off, then flips back **on** after ~75s (coordinator flag re-asserted) — confirmed with the app both open and fully closed, so it's app-independent.

With this patch the restored **off** is re-applied to the coordinator on add, so the switch stays off and BLE is not re-enabled across reloads/restarts.
