### PR TITLE
fix: improve error message fallback in get_error_message

### DIFF
--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -2218,6 +2218,12 @@ class MammotionDeviceErrorUpdateCoordinator(
             if solution == "":
                 solution = error_info.en_solution
 
+            if not implication.strip() and not solution.strip():
+                return f"{error_info.module}: unknown error (code {error_code})"
+            if not solution.strip():
+                return f"{error_info.module}: {implication}"
+            if not implication.strip():
+                return f"{error_info.module}: {solution}"
             return f"{error_info.module}: {implication}, {solution}"
 
         except StopIteration:
@@ -2225,7 +2231,7 @@ class MammotionDeviceErrorUpdateCoordinator(
             return "No Error"
         except KeyError:
             """Failed to get error message."""
-            return "Error message not found"
+            return f"Unknown error (code {error_code})"
 
     async def _async_update_data(self) -> MowingDevice:
         """Get data from the device."""
@@ -2556,11 +2562,17 @@ class MammotionSpinoCoordinator(MammotionBaseUpdateCoordinator[PoolCleanerDevice
                 implication = error_info.en_implication
             if solution == "":
                 solution = error_info.en_solution
+            if not implication.strip() and not solution.strip():
+                return f"{error_info.module}: unknown error (code {error_code})"
+            if not solution.strip():
+                return f"{error_info.module}: {implication}"
+            if not implication.strip():
+                return f"{error_info.module}: {solution}"
             return f"{error_info.module}: {implication}, {solution}"
         except IndexError:
             return "No Error"
         except KeyError:
-            return "Error message not found"
+            return f"Unknown error (code {error_code})"
 
     async def _async_update_data(self) -> PoolCleanerDevice:
         """Return current pool cleaner state from the device handle.


### PR DESCRIPTION
## Problem

When a mower reports an error code that is either:
1. **Not present in the cloud API error codes dictionary** (e.g. code `3000001`), the sensor shows the generic message `Error message not found` with no way to identify which error occurred.
2. **Present in the dictionary but with empty implication/solution fields** (e.g. code `1030`), the sensor shows a confusing `mcu: , ` format.

## Fix

Two improvements in both `MammotionDeviceErrorUpdateCoordinator.get_error_message()` and `MammotionSpinoCoordinator.get_error_message()`:

1. **KeyError fallback**: Include the numeric error code in the message → `Unknown error (code 3000001)` instead of `Error message not found`.
2. **Empty fields handling**: When both implication and solution are blank, show `module: unknown error (code N)`. When only one is blank, omit the empty field instead of showing a trailing/leading comma.

### Before
```
Error message not found     ← code not in dictionary
mcu: ,                       ← code found but fields empty
```

### After
```
Unknown error (code 3000001) ← code not in dictionary
mcu: unknown error (code 1030) ← code found but fields empty
```
