### PR TITLE
mammotion: add map image entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Satellite map tiles (Google Maps, OpenStreetMap, etc.) are sometimes misaligned 
 
 Typical offsets are within ±20 m. Positive latitude = north, positive longitude = east.
 
+The map image keeps the most recently completed mowing trail visible until the
+next task starts. Trail points are stored locally so they survive Home Assistant
+restarts.
+
 ## Dashboard Plugins
 
 Companion HACS dashboard plugins that extend the Mammotion integration with visual tools.

--- a/custom_components/mammotion/__init__.py
+++ b/custom_components/mammotion/__init__.py
@@ -97,6 +97,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.IMAGE,
     Platform.CAMERA,
     Platform.UPDATE,
     Platform.VACUUM,

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -1434,7 +1434,9 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
 
         return _wrapper
 
-    def subscribe_map_updated(self, handler: Callable[[], None]) -> None:
+    def subscribe_map_updated(
+        self, handler: Callable[[], None]
+    ) -> Callable[[], None] | None:
         """Subscribe *handler* to map-updated events from the device handle.
 
         Fires only when ``toapp_all_hash_name`` is received or a ``MapFetchSaga``
@@ -1443,13 +1445,21 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
         """
         handle = self.manager.mower(self.device_name)
         if handle is None:
-            return
+            return None
 
         async def _on_map_updated() -> None:
             if not self.hass.is_stopping:
                 handler()
 
-        self._subscriptions.append(handle.subscribe_map_updated(_on_map_updated))
+        subscription = handle.subscribe_map_updated(_on_map_updated)
+        self._subscriptions.append(subscription)
+
+        def _unsubscribe() -> None:
+            subscription.cancel()
+            if subscription in self._subscriptions:
+                self._subscriptions.remove(subscription)
+
+        return _unsubscribe
 
     async def async_shutdown(self) -> None:
         """Flush queued state, cancel RAII subscriptions and shut down the coordinator."""

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import datetime
 import json
+import math
 import secrets
 import time
 from abc import abstractmethod
@@ -106,6 +107,24 @@ DEVICE_VERSION_INTERVAL = timedelta(weeks=1)
 MAP_INTERVAL = timedelta(minutes=60)
 RTK_INTERVAL = timedelta(hours=5)
 SPINO_INTERVAL = timedelta(weeks=1)
+LOCATION_TRAIL_MAX_POINTS = 5000
+LOCATION_TRAIL_MIN_DISTANCE_METERS = 0.25
+LOCATION_TRAIL_SAVE_INTERVAL = 30
+LOCATION_TRAIL_STORE_VERSION = 1
+
+
+def _distance_meters(first: tuple[float, float], second: tuple[float, float]) -> float:
+    """Return the approximate distance between two longitude/latitude points."""
+    first_lon, first_lat = first
+    second_lon, second_lat = second
+    mean_lat = math.radians((first_lat + second_lat) / 2)
+    metres_per_lat = 111_111.0
+    metres_per_lon = 111_111.0 * max(math.cos(mean_lat), 0.01)
+    return math.hypot(
+        (second_lon - first_lon) * metres_per_lon,
+        (second_lat - first_lat) * metres_per_lat,
+    )
+
 
 # Possible states for ``MammotionReportUpdateCoordinator.map_sync_status`` and
 # the ``map_sync_status`` diagnostic ENUM sensor that surfaces it.
@@ -1525,6 +1544,16 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         )
 
         self._on_stop: list[CALLBACK_TYPE] = []
+        self.location_trail: list[tuple[float, float]] = []
+        self._location_trail_active = False
+        self._location_trail_restored = False
+        self._location_trail_resume_pending = False
+        self._location_trail_save_cancel: CALLBACK_TYPE | None = None
+        self._location_trail_store = Store[dict[str, Any]](
+            hass,
+            LOCATION_TRAIL_STORE_VERSION,
+            f"{DOMAIN}.location_trail.{config_entry.entry_id}.{device.device_name}",
+        )
 
         self.poll_debouncer = Debouncer(
             hass,
@@ -1611,9 +1640,124 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
         """Get coordinator data."""
         return device
 
+    @staticmethod
+    def _is_location_trail_active(device: MowingDevice) -> bool:
+        """Return whether mower movement belongs to an active task."""
+        try:
+            return int(device.report_data.dev.sys_status) in MOWING_ACTIVE_MODES
+        except TypeError, ValueError:
+            return False
+
+    @staticmethod
+    def _has_resume_breakpoint(device: MowingDevice) -> bool:
+        """Return whether the current task can resume from a breakpoint."""
+        try:
+            return int(device.report_data.work.bp_info) != 0
+        except AttributeError, TypeError, ValueError:
+            return False
+
+    async def _async_restore_location_trail(self) -> None:
+        """Restore the current or most recently completed task trail."""
+        if self._location_trail_restored:
+            return
+        self._location_trail_restored = True
+        stored = await self._location_trail_store.async_load()
+        if not isinstance(stored, dict):
+            return
+
+        points = stored.get("points")
+        if not isinstance(points, list):
+            return
+
+        restored: list[tuple[float, float]] = []
+        for point in points[-LOCATION_TRAIL_MAX_POINTS:]:
+            if not isinstance(point, (list, tuple)) or len(point) != 2:
+                continue
+            try:
+                longitude = float(point[0])
+                latitude = float(point[1])
+            except TypeError, ValueError:
+                continue
+            if (
+                -180 <= longitude <= 180
+                and -90 <= latitude <= 90
+                and (longitude != 0 or latitude != 0)
+            ):
+                restored.append((longitude, latitude))
+
+        self.location_trail = restored
+        self._location_trail_active = bool(stored.get("active"))
+        self._location_trail_resume_pending = bool(stored.get("resume_pending"))
+
+    def _update_location_trail(self, device: MowingDevice) -> None:
+        """Track mower positions and retain the completed trail until the next task."""
+        active = self._is_location_trail_active(device)
+        state_changed = active != self._location_trail_active
+        previous_resume_pending = self._location_trail_resume_pending
+        if active and not self._location_trail_active:
+            if self.location_trail and not self._location_trail_resume_pending:
+                self.location_trail.clear()
+            self._location_trail_resume_pending = False
+        elif not active:
+            self._location_trail_resume_pending = self._has_resume_breakpoint(device)
+        self._location_trail_active = active
+        if (
+            state_changed
+            or self._location_trail_resume_pending != previous_resume_pending
+        ):
+            self._schedule_location_trail_save()
+        if not active:
+            return
+
+        location = getattr(getattr(device, "location", None), "device", None)
+        try:
+            point = (float(location.longitude), float(location.latitude))
+        except AttributeError, TypeError, ValueError:
+            return
+        if not (-180 <= point[0] <= 180 and -90 <= point[1] <= 90) or point == (
+            0,
+            0,
+        ):
+            return
+        if self.location_trail and (
+            _distance_meters(self.location_trail[-1], point)
+            < LOCATION_TRAIL_MIN_DISTANCE_METERS
+        ):
+            return
+
+        self.location_trail.append(point)
+        if len(self.location_trail) > LOCATION_TRAIL_MAX_POINTS:
+            del self.location_trail[:-LOCATION_TRAIL_MAX_POINTS]
+        self._schedule_location_trail_save()
+
+    def _schedule_location_trail_save(self) -> None:
+        """Persist trail progress at a bounded interval while moving."""
+        if self._location_trail_save_cancel is not None:
+            return
+        self._location_trail_save_cancel = async_call_later(
+            self.hass,
+            LOCATION_TRAIL_SAVE_INTERVAL,
+            self._async_save_location_trail,
+        )
+
+    async def _async_save_location_trail(
+        self, _now: datetime.datetime | None = None
+    ) -> None:
+        """Write the retained trail to storage."""
+        self._location_trail_save_cancel = None
+        await self._location_trail_store.async_save(
+            {
+                "active": self._location_trail_active,
+                "resume_pending": self._location_trail_resume_pending,
+                "points": self.location_trail[-LOCATION_TRAIL_MAX_POINTS:],
+            }
+        )
+
     async def _async_update_data(self) -> MowingDevice:
         """Get data from the device."""
+        await self._async_restore_location_trail()
         if data := await super()._async_update_data():
+            self._update_location_trail(data)
             return data
 
         device = self.manager.get_device_by_name(self.device_name)
@@ -1623,6 +1767,7 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
 
         LOGGER.debug("Updated Mammotion device %s", self.device_name)
         self.update_failures = 0
+        self._update_location_trail(device)
         await self.async_save_data(device)
 
         if self.data.mower_state.ble_mac != "" and len(self._on_stop) == 0:
@@ -1656,6 +1801,21 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
 
         return device
 
+    async def _on_state_changed(self, snapshot: DeviceSnapshot) -> None:
+        """Track location and push updated device data to Home Assistant."""
+        data = cast(MowingDevice, snapshot.raw)
+        self._update_location_trail(data)
+        self.async_set_updated_data(data)
+
+    async def async_shutdown(self) -> None:
+        """Flush retained trail state before shutting down."""
+        if self._location_trail_save_cancel is not None:
+            self._location_trail_save_cancel()
+            self._location_trail_save_cancel = None
+        if self._location_trail_restored:
+            await self._async_save_location_trail()
+        await super().async_shutdown()
+
     async def _async_update_properties(
         self, properties: ThingPropertiesMessage
     ) -> None:
@@ -1687,6 +1847,7 @@ class MammotionReportUpdateCoordinator(MammotionBaseUpdateCoordinator[MowingDevi
             self.async_set_updated_data(device)
 
     async def _async_setup(self) -> None:
+        await self._async_restore_location_trail()
         await super()._async_setup()
 
         # Common commands for all device types

--- a/custom_components/mammotion/icons.json
+++ b/custom_components/mammotion/icons.json
@@ -5,6 +5,11 @@
         "default": "mdi:map-marker-radius"
       }
     },
+    "image": {
+      "map": {
+        "default": "mdi:map"
+      }
+    },
     "button": {
       "start_map_sync": {
         "default": "mdi:map-clock"

--- a/custom_components/mammotion/image.py
+++ b/custom_components/mammotion/image.py
@@ -1,0 +1,276 @@
+"""Mammotion map image entities."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import time
+from copy import copy
+from typing import Any
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from pymammotion.utility.device_type import DeviceType
+from pymammotion.utility.map_renderer import placeholder_png, render_map_png
+
+from . import MammotionConfigEntry
+from .coordinator import (
+    MammotionMapUpdateCoordinator,
+    MammotionReportUpdateCoordinator,
+)
+from .entity import MammotionBaseEntity
+from .geojson_utils import apply_coord, apply_geojson_offset
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MammotionConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up map image entities."""
+    async_add_entities(
+        MammotionMapImage(
+            mower.reporting_coordinator,
+            mower.map_coordinator,
+            hass,
+        )
+        for mower in entry.runtime_data.mowers
+    )
+
+
+class MammotionMapImage(MammotionBaseEntity, ImageEntity):
+    """Static rendered mower map."""
+
+    _RENDER_CACHE_SECONDS = 300.0
+
+    _attr_translation_key = "map"
+    _attr_content_type = "image/png"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: MammotionReportUpdateCoordinator,
+        map_coordinator: MammotionMapUpdateCoordinator,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the map image."""
+        MammotionBaseEntity.__init__(self, coordinator, "map")
+        ImageEntity.__init__(self, hass)
+        self._map_coordinator = map_coordinator
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self._cached_png: bytes | None = None
+        self._last_content_key: str | None = None
+        self._last_render_time = 0.0
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh rendered image when the mower map changes."""
+        await super().async_added_to_hass()
+        self.coordinator.subscribe_map_updated(self._handle_map_update)
+        self.async_on_remove(
+            self._map_coordinator.async_add_listener(self._handle_map_update)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Invalidate image when live mower telemetry changes."""
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        super()._handle_coordinator_update()
+
+    @callback
+    def _handle_map_update(self) -> None:
+        """Invalidate image when static map data changes."""
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self.async_write_ha_state()
+
+    async def async_image(self) -> bytes | None:
+        """Return a rendered map image."""
+        mower = self.coordinator.manager.get_device_by_name(
+            self.coordinator.device_name
+        )
+        if mower is None:
+            return placeholder_png()
+
+        offset_lat = self.coordinator.map_offset_lat
+        offset_lon = self.coordinator.map_offset_lon
+        geojson = self._merged_geojson(mower)
+        if geojson is not None:
+            geojson = apply_geojson_offset(geojson, offset_lat, offset_lon)
+        mower_location = self._offset_location(
+            mower.location.device, offset_lat, offset_lon
+        )
+        mower_trail = self._offset_trail(
+            list(getattr(self.coordinator, "location_trail", [])),
+            offset_lat,
+            offset_lon,
+        )
+        content_key = self._content_key(
+            geojson,
+            mower_location,
+            mower_trail,
+            offset_lat,
+            offset_lon,
+        )
+        now = time.monotonic()
+        if (
+            self._cached_png is not None
+            and content_key == self._last_content_key
+            and now - self._last_render_time < self._RENDER_CACHE_SECONDS
+        ):
+            return self._cached_png
+
+        tile_cache_dir = self.hass.config.path(".storage", "mammotion_osm_tiles")
+        self._cached_png = await render_map_png(
+            geojson,
+            tile_cache_dir,
+            mower_location,
+            mower_trail,
+        )
+        self._last_content_key = content_key
+        self._last_render_time = now
+        return self._cached_png
+
+    def _merged_geojson(self, mower: Any) -> dict[str, Any] | None:
+        base_geojson = MammotionMapImage._base_geojson(
+            getattr(mower.map, "generated_geojson", None)
+        )
+        device_type = DeviceType.value_of_str(self.coordinator.device_name)
+        firmware = mower.device_firmwares.main_controller
+        if device_type.is_support_dynamics_line(firmware):
+            progress_geojson = mower.map.generated_dynamics_line_geojson
+        else:
+            progress_geojson = mower.map.generated_mow_progress_geojson
+        feature_collections = [
+            base_geojson,
+            MammotionMapImage._line_geojson(progress_geojson),
+        ]
+        features: list[dict[str, Any]] = []
+        for geojson in feature_collections:
+            if isinstance(geojson, dict):
+                features.extend(geojson.get("features") or [])
+        if not features:
+            return None
+        return {
+            "type": "FeatureCollection",
+            "name": "Mammotion Map",
+            "features": features,
+        }
+
+    @staticmethod
+    def _base_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep persistent map geometry and drop stale route/progress overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if MammotionMapImage._is_base_map_feature(feature)
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _line_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep only line geometry from live task overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if (feature.get("geometry") or {}).get("type")
+            in {"LineString", "MultiLineString"}
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _is_base_map_feature(feature: dict[str, Any]) -> bool:
+        properties = feature.get("properties") or {}
+        type_name = str(
+            properties.get("type_name")
+            or properties.get("type")
+            or properties.get("Type")
+            or ""
+        ).lower()
+        return type_name in {
+            "area",
+            "charging_station",
+            "corridor_line",
+            "corridor_point",
+            "dump",
+            "no_go_zone",
+            "obstacle",
+            "path",
+            "station",
+            "svg",
+            "virtual_wall",
+            "visual_obstacle_zone",
+            "visual_safety_zone",
+        }
+
+    @staticmethod
+    def _content_key(
+        geojson: dict[str, Any] | None,
+        mower_location: Any | None,
+        mower_trail: list[tuple[float, float]],
+        offset_lat: float,
+        offset_lon: float,
+    ) -> str:
+        location_key = None
+        if mower_location is not None:
+            location_key = (
+                round(float(getattr(mower_location, "longitude")), 7),
+                round(float(getattr(mower_location, "latitude")), 7),
+            )
+        payload = {
+            "geojson": geojson,
+            "location": location_key,
+            "trail": [
+                (round(float(lon), 7), round(float(lat), 7))
+                for lon, lat in mower_trail[-80:]
+            ],
+            "offset": (round(offset_lat, 3), round(offset_lon, 3)),
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _offset_location(
+        location: Any | None,
+        offset_lat: float,
+        offset_lon: float,
+    ) -> Any | None:
+        if location is None:
+            return None
+        latitude = getattr(location, "latitude", None)
+        longitude = getattr(location, "longitude", None)
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except TypeError, ValueError:
+            return None
+        if latitude == 0.0 and longitude == 0.0:
+            return None
+        shifted = apply_coord([longitude, latitude], latitude, offset_lat, offset_lon)
+        shifted_location = copy(location)
+        shifted_location.longitude = shifted[0]
+        shifted_location.latitude = shifted[1]
+        return shifted_location
+
+    @staticmethod
+    def _offset_trail(
+        trail: list[tuple[float, float]],
+        offset_lat: float,
+        offset_lon: float,
+    ) -> list[tuple[float, float]]:
+        shifted_trail: list[tuple[float, float]] = []
+        for longitude, latitude in trail:
+            shifted = apply_coord(
+                [float(longitude), float(latitude)],
+                float(latitude),
+                offset_lat,
+                offset_lon,
+            )
+            shifted_trail.append((shifted[0], shifted[1]))
+        return shifted_trail

--- a/custom_components/mammotion/image.py
+++ b/custom_components/mammotion/image.py
@@ -1,0 +1,392 @@
+"""Mammotion map image entities."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import hashlib
+import json
+import time
+from copy import copy
+from typing import Any
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from pymammotion.utility.device_type import DeviceType
+from pymammotion.utility.map_renderer import placeholder_png, render_map_png
+
+from . import MammotionConfigEntry
+from .coordinator import MammotionReportUpdateCoordinator
+from .entity import MammotionBaseEntity
+from .geojson_utils import apply_coord, apply_geojson_offset
+
+_IMAGE_RENDER_TIMEOUT = 8
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MammotionConfigEntry,
+    async_add_entities,
+) -> None:
+    """Set up map image entities."""
+    async_add_entities(
+        MammotionMapImage(
+            mower.reporting_coordinator,
+            hass,
+        )
+        for mower in entry.runtime_data.mowers
+    )
+
+
+class MammotionMapImage(MammotionBaseEntity, ImageEntity):
+    """Static rendered mower map."""
+
+    _RENDER_CACHE_SECONDS = 300.0
+    _LOCATION_PRECISION = 5
+    _PLACEHOLDER_CONTENT_KEY = "placeholder"
+
+    _attr_translation_key = "map"
+    _attr_content_type = "image/png"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: MammotionReportUpdateCoordinator,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize the map image."""
+        MammotionBaseEntity.__init__(self, coordinator, "map")
+        ImageEntity.__init__(self, hass)
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self._cached_png: bytes | None = None
+        self._last_content_key: str | None = None
+        self._notified_content_key: str | None = None
+        self._last_render_time = 0.0
+        self._geometry_sources: tuple[object | None, ...] | None = None
+        self._geometry_offset: tuple[float, float] | None = None
+        self._geometry_geojson: dict[str, Any] | None = None
+        self._geometry_key = ""
+        self._render_lock = asyncio.Lock()
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh rendered image when the mower map changes."""
+        await super().async_added_to_hass()
+        if unsubscribe := self.coordinator.subscribe_map_updated(
+            self._handle_map_update
+        ):
+            self.async_on_remove(unsubscribe)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Invalidate image when live mower telemetry changes."""
+        content_key = self._current_content_key()
+        if content_key != self._notified_content_key:
+            self._notified_content_key = content_key
+            self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        super()._handle_coordinator_update()
+
+    @callback
+    def _handle_map_update(self) -> None:
+        """Invalidate image when static map data changes."""
+        self._cached_png = None
+        self._geometry_sources = None
+        self._notified_content_key = None
+        self._attr_image_last_updated = datetime.datetime.now(datetime.UTC)
+        self.async_write_ha_state()
+
+    async def async_image(self) -> bytes | None:
+        """Return a rendered map image."""
+        async with self._render_lock:
+            # Re-read after waiting: another caller may have rendered this key,
+            # or fresh telemetry may have replaced the requested image.
+            payload = self._image_payload()
+            if payload is None:
+                self._notified_content_key = self._PLACEHOLDER_CONTENT_KEY
+                return placeholder_png()
+
+            geojson, mower_location, content_key = payload
+            now = time.monotonic()
+            if (
+                self._cached_png is not None
+                and content_key == self._last_content_key
+                and now - self._last_render_time < self._RENDER_CACHE_SECONDS
+            ):
+                return self._cached_png
+
+            tile_cache_dir = self.hass.config.path(
+                ".storage", "mammotion_osm_tiles"
+            )
+            try:
+                async with asyncio.timeout(_IMAGE_RENDER_TIMEOUT):
+                    rendered = await render_map_png(
+                        geojson,
+                        tile_cache_dir,
+                        mower_location,
+                    )
+            except TimeoutError:
+                # Let the next coordinator tick announce the same content key
+                # again so HA retries a render that exceeded its image deadline.
+                self._notified_content_key = None
+                return self._cached_png or placeholder_png()
+            self._cached_png = rendered
+            self._last_content_key = content_key
+            self._notified_content_key = content_key
+            self._last_render_time = now
+            return self._cached_png
+
+    def _current_content_key(self) -> str:
+        """Return the key for the image Home Assistant should fetch."""
+        payload = self._image_payload()
+        if payload is None:
+            return self._PLACEHOLDER_CONTENT_KEY
+        return payload[2]
+
+    def _image_payload(self) -> tuple[dict[str, Any] | None, Any | None, str] | None:
+        """Return render inputs and their stable content key."""
+        mower = self.coordinator.manager.get_device_by_name(
+            self.coordinator.device_name
+        )
+        if mower is None or not self._has_renderable_map(mower):
+            return None
+
+        offset_lat = self.coordinator.map_offset_lat
+        offset_lon = self.coordinator.map_offset_lon
+        geojson, geometry_key = self._geometry_payload(mower, offset_lat, offset_lon)
+        mower_location = self._offset_location(
+            mower.location.device, offset_lat, offset_lon
+        )
+        content_key = self._content_key(
+            geometry_key,
+            mower_location,
+        )
+        return geojson, mower_location, content_key
+
+    def _geometry_payload(
+        self,
+        mower: Any,
+        offset_lat: float,
+        offset_lon: float,
+    ) -> tuple[dict[str, Any] | None, str]:
+        """Return cached render geometry and a stable digest."""
+        sources = self._geojson_sources(mower)
+        offset = (offset_lat, offset_lon)
+        if (
+            self._geometry_sources is not None
+            and len(sources) == len(self._geometry_sources)
+            and all(
+                current is cached
+                for current, cached in zip(
+                    sources[:-1], self._geometry_sources[:-1], strict=True
+                )
+            )
+            and sources[-1] == self._geometry_sources[-1]
+            and offset == self._geometry_offset
+        ):
+            return self._geometry_geojson, self._geometry_key
+
+        geojson = self._merged_geojson(sources)
+        if geojson is not None:
+            geojson = apply_geojson_offset(geojson, offset_lat, offset_lon)
+        encoded = json.dumps(
+            geojson,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        self._geometry_sources = sources
+        self._geometry_offset = offset
+        self._geometry_geojson = geojson
+        self._geometry_key = hashlib.sha256(encoded).hexdigest()
+        return geojson, self._geometry_key
+
+    def _has_synced_map(self, mower: Any) -> bool:
+        """Return whether the map cache is complete enough to render."""
+        locations = mower.report_data.locations
+        bol_hash = locations[0].bol_hash if locations else 0
+        return self.coordinator.map_sync_status == "synced" and mower.map.is_map_synced(
+            bol_hash
+        )
+
+    def _has_renderable_map(self, mower: Any) -> bool:
+        """Keep the last complete generated map visible between synchronizations."""
+        if self._has_synced_map(mower):
+            return True
+        return self._base_geojson(mower.map.generated_geojson) is not None
+
+    def _geojson_sources(self, mower: Any) -> tuple[object | None, ...]:
+        """Return the map objects whose identities define rendered geometry."""
+        base_geojson = getattr(mower.map, "generated_geojson", None)
+        mow_path_geojson = getattr(mower.map, "generated_mow_path_geojson", None)
+        device_type = DeviceType.value_of_str(self.coordinator.device_name)
+        firmware = mower.device_firmwares.main_controller
+        dynamics_geojson = mower.map.generated_dynamics_line_geojson
+        if device_type.is_support_dynamics_line(firmware) and self._has_line_geometry(
+            dynamics_geojson
+        ):
+            progress_geojson = dynamics_geojson
+        else:
+            progress_geojson = mower.map.generated_mow_progress_geojson
+        area_names = tuple(
+            sorted(
+                (
+                    int(area.hash),
+                    str(getattr(area, "name", "") or "").strip(),
+                )
+                for area in getattr(mower.map, "area_name", ())
+                if str(getattr(area, "hash", "")).lstrip("-").isdigit()
+            )
+        )
+        return base_geojson, mow_path_geojson, progress_geojson, area_names
+
+    @staticmethod
+    def _has_line_geometry(geojson: dict[str, Any] | None) -> bool:
+        """Return whether a native progress payload contains a usable line."""
+        return isinstance(geojson, dict) and any(
+            (feature.get("geometry") or {}).get("type")
+            in {"LineString", "MultiLineString"}
+            for feature in geojson.get("features") or []
+        )
+
+    @staticmethod
+    def _merged_geojson(
+        sources: tuple[object | None, ...],
+    ) -> dict[str, Any] | None:
+        base_geojson = MammotionMapImage._base_geojson(
+            sources[0] if isinstance(sources[0], dict) else None
+        )
+        mow_path_geojson = MammotionMapImage._line_geojson(
+            sources[1] if isinstance(sources[1], dict) else None
+        )
+        area_names = dict(sources[3]) if len(sources) > 3 else {}
+        feature_collections = [
+            base_geojson,
+            mow_path_geojson,
+            MammotionMapImage._line_geojson(
+                sources[2] if isinstance(sources[2], dict) else None
+            ),
+        ]
+        features: list[dict[str, Any]] = []
+        for geojson in feature_collections:
+            if isinstance(geojson, dict):
+                for feature in geojson.get("features") or []:
+                    properties = feature.get("properties") or {}
+                    try:
+                        area_id = int(properties.get("hash"))
+                    except (TypeError, ValueError):
+                        area_id = 0
+                    if area_id in area_names and area_names[area_id]:
+                        feature = {
+                            **feature,
+                            "properties": {
+                                **properties,
+                                "Name": area_names[area_id],
+                            },
+                        }
+                    features.append(feature)
+        if not features:
+            return None
+        return {
+            "type": "FeatureCollection",
+            "name": "Mammotion Map",
+            "features": features,
+        }
+
+    @staticmethod
+    def _base_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep persistent map geometry and drop stale route/progress overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if MammotionMapImage._is_base_map_feature(feature)
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _line_geojson(geojson: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Keep only line geometry from live task overlays."""
+        if not isinstance(geojson, dict):
+            return None
+        features = [
+            feature
+            for feature in geojson.get("features") or []
+            if (feature.get("geometry") or {}).get("type")
+            in {"LineString", "MultiLineString"}
+        ]
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
+    @staticmethod
+    def _is_base_map_feature(feature: dict[str, Any]) -> bool:
+        properties = feature.get("properties") or {}
+        type_name = str(
+            properties.get("type_name")
+            or properties.get("type")
+            or properties.get("Type")
+            or ""
+        ).lower()
+        return type_name in {
+            "area",
+            "charging_station",
+            "corridor_line",
+            "corridor_point",
+            "dump",
+            "no_go_zone",
+            "obstacle",
+            "path",
+            "station",
+            "svg",
+            "virtual_wall",
+            "visual_obstacle_zone",
+            "visual_safety_zone",
+        }
+
+    @staticmethod
+    def _content_key(
+        geometry_key: str,
+        mower_location: Any | None,
+    ) -> str:
+        location_key = None
+        if mower_location is not None:
+            location_key = (
+                round(
+                    float(mower_location.longitude),
+                    MammotionMapImage._LOCATION_PRECISION,
+                ),
+                round(
+                    float(mower_location.latitude),
+                    MammotionMapImage._LOCATION_PRECISION,
+                ),
+            )
+        payload = {
+            "geometry": geometry_key,
+            "location": location_key,
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _offset_location(
+        location: Any | None,
+        offset_lat: float,
+        offset_lon: float,
+    ) -> Any | None:
+        if location is None:
+            return None
+        latitude = getattr(location, "latitude", None)
+        longitude = getattr(location, "longitude", None)
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+        except TypeError, ValueError:
+            return None
+        if latitude == 0.0 and longitude == 0.0:
+            return None
+        shifted = apply_coord([longitude, latitude], latitude, offset_lat, offset_lon)
+        shifted_location = copy(location)
+        shifted_location.longitude = shifted[0]
+        shifted_location.latitude = shifted[1]
+        return shifted_location

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -50,6 +50,14 @@ class MammotionSpinoNumberEntityDescription(NumberEntityDescription):  # type: i
     set_fn: Callable[[MammotionSpinoCoordinator, float], Awaitable[None]]
 
 
+def _set_map_offset(
+    coordinator: MammotionBaseUpdateCoordinator[Any], attribute: str, value: float
+) -> None:
+    """Set a map offset and refresh entities using the adjusted coordinates."""
+    setattr(coordinator, attribute, value)
+    coordinator.async_update_listeners()
+
+
 SPINO_NUMBER_ENTITIES: tuple[MammotionSpinoNumberEntityDescription, ...] = (
     MammotionSpinoNumberEntityDescription(
         key="spino_floor_speed",
@@ -75,7 +83,9 @@ MAP_OFFSET_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         native_min_value=-50,
         native_max_value=50,
         mode=NumberMode.BOX,
-        set_fn=lambda coordinator, value: setattr(coordinator, "map_offset_lat", value),
+        set_fn=lambda coordinator, value: _set_map_offset(
+            coordinator, "map_offset_lat", value
+        ),
         get_fn=lambda coordinator: coordinator.map_offset_lat,
     ),
     MammotionConfigNumberEntityDescription(
@@ -86,7 +96,9 @@ MAP_OFFSET_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         native_min_value=-50,
         native_max_value=50,
         mode=NumberMode.BOX,
-        set_fn=lambda coordinator, value: setattr(coordinator, "map_offset_lon", value),
+        set_fn=lambda coordinator, value: _set_map_offset(
+            coordinator, "map_offset_lon", value
+        ),
         get_fn=lambda coordinator: coordinator.map_offset_lon,
     ),
 )

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -50,6 +50,14 @@ class MammotionSpinoNumberEntityDescription(NumberEntityDescription):  # type: i
     set_fn: Callable[[MammotionSpinoCoordinator, float], Awaitable[None]]
 
 
+def _set_map_offset(
+    coordinator: MammotionBaseUpdateCoordinator[Any], attribute: str, value: float
+) -> None:
+    """Set a map offset and refresh entities using the adjusted coordinates."""
+    setattr(coordinator, attribute, value)
+    coordinator.async_update_listeners()
+
+
 SPINO_NUMBER_ENTITIES: tuple[MammotionSpinoNumberEntityDescription, ...] = (
     MammotionSpinoNumberEntityDescription(
         key="spino_floor_speed",
@@ -73,7 +81,9 @@ MAP_OFFSET_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         native_min_value=-50,
         native_max_value=50,
         mode=NumberMode.BOX,
-        set_fn=lambda coordinator, value: setattr(coordinator, "map_offset_lat", value),
+        set_fn=lambda coordinator, value: _set_map_offset(
+            coordinator, "map_offset_lat", value
+        ),
         get_fn=lambda coordinator: coordinator.map_offset_lat,
     ),
     MammotionConfigNumberEntityDescription(
@@ -84,7 +94,9 @@ MAP_OFFSET_ENTITIES: tuple[MammotionConfigNumberEntityDescription, ...] = (
         native_min_value=-50,
         native_max_value=50,
         mode=NumberMode.BOX,
-        set_fn=lambda coordinator, value: setattr(coordinator, "map_offset_lon", value),
+        set_fn=lambda coordinator, value: _set_map_offset(
+            coordinator, "map_offset_lon", value
+        ),
         get_fn=lambda coordinator: coordinator.map_offset_lon,
     ),
 )

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Device Tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -473,6 +473,11 @@
     },
     "device_tracker": {
       "name": "Device Tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/cs.json
+++ b/custom_components/mammotion/translations/cs.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Sledování zařízení"
+    },
+    "image": {
+      "map": {
+        "name": "Mapa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/cs.json
+++ b/custom_components/mammotion/translations/cs.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Sledování zařízení"
+    },
+    "image": {
+      "map": {
+        "name": "Mapa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/da.json
+++ b/custom_components/mammotion/translations/da.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Enhedssporing"
+    },
+    "image": {
+      "map": {
+        "name": "Kort"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/da.json
+++ b/custom_components/mammotion/translations/da.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Enhedssporing"
+    },
+    "image": {
+      "map": {
+        "name": "Kort"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/de.json
+++ b/custom_components/mammotion/translations/de.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Geräteverfolgung"
+    },
+    "image": {
+      "map": {
+        "name": "Karte"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/de.json
+++ b/custom_components/mammotion/translations/de.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Geräteverfolgung"
+    },
+    "image": {
+      "map": {
+        "name": "Karte"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Device tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -610,6 +610,11 @@
     },
     "device_tracker": {
       "name": "Device tracking"
+    },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/fr.json
+++ b/custom_components/mammotion/translations/fr.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Suivi de l'appareil"
+    },
+    "image": {
+      "map": {
+        "name": "Carte"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/fr.json
+++ b/custom_components/mammotion/translations/fr.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Suivi de l'appareil"
+    },
+    "image": {
+      "map": {
+        "name": "Carte"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/hu.json
+++ b/custom_components/mammotion/translations/hu.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Eszközkövetés"
+    },
+    "image": {
+      "map": {
+        "name": "Térkép"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/hu.json
+++ b/custom_components/mammotion/translations/hu.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Eszközkövetés"
+    },
+    "image": {
+      "map": {
+        "name": "Térkép"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/it.json
+++ b/custom_components/mammotion/translations/it.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Tracciamento del dispositivo"
+    },
+    "image": {
+      "map": {
+        "name": "Mappa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/it.json
+++ b/custom_components/mammotion/translations/it.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Tracciamento del dispositivo"
+    },
+    "image": {
+      "map": {
+        "name": "Mappa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/nl.json
+++ b/custom_components/mammotion/translations/nl.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Apparaat volgen"
+    },
+    "image": {
+      "map": {
+        "name": "Kaart"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/nl.json
+++ b/custom_components/mammotion/translations/nl.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Apparaat volgen"
+    },
+    "image": {
+      "map": {
+        "name": "Kaart"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/pl.json
+++ b/custom_components/mammotion/translations/pl.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Śledzenie urządzenia"
+    },
+    "image": {
+      "map": {
+        "name": "Mapa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/pl.json
+++ b/custom_components/mammotion/translations/pl.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Śledzenie urządzenia"
+    },
+    "image": {
+      "map": {
+        "name": "Mapa"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/ro.json
+++ b/custom_components/mammotion/translations/ro.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Monitorizarea dispozitivului"
+    },
+    "image": {
+      "map": {
+        "name": "Hartă"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/ro.json
+++ b/custom_components/mammotion/translations/ro.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Monitorizarea dispozitivului"
+    },
+    "image": {
+      "map": {
+        "name": "Hartă"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/sl.json
+++ b/custom_components/mammotion/translations/sl.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Sledenje"
+    },
+    "image": {
+      "map": {
+        "name": "Zemljevid"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/sl.json
+++ b/custom_components/mammotion/translations/sl.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Sledenje"
+    },
+    "image": {
+      "map": {
+        "name": "Zemljevid"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/sv.json
+++ b/custom_components/mammotion/translations/sv.json
@@ -625,6 +625,11 @@
     },
     "device_tracker": {
       "name": "Spårning av enhet"
+    },
+    "image": {
+      "map": {
+        "name": "Karta"
+      }
     }
   },
   "selector": {

--- a/custom_components/mammotion/translations/sv.json
+++ b/custom_components/mammotion/translations/sv.json
@@ -584,6 +584,11 @@
     },
     "device_tracker": {
       "name": "Spårning av enhet"
+    },
+    "image": {
+      "map": {
+        "name": "Karta"
+      }
     }
   },
   "selector": {

--- a/tests/test_map_image.py
+++ b/tests/test_map_image.py
@@ -1,0 +1,332 @@
+"""Focused tests for map image invalidation and native geometry selection."""
+
+# ruff: noqa: SLF001
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _load_image_module(monkeypatch):
+    class ImageEntity:
+        def __init__(self, hass):
+            self.hass = hass
+
+        def _handle_coordinator_update(self) -> None:
+            pass
+
+    class MammotionBaseEntity:
+        def __init__(self, coordinator, _key):
+            self.coordinator = coordinator
+
+        def _handle_coordinator_update(self) -> None:
+            pass
+
+    class DeviceType:
+        @staticmethod
+        def value_of_str(_device_name):
+            return SimpleNamespace(is_support_dynamics_line=lambda _firmware: True)
+
+    package_names = (
+        "custom_components",
+        "custom_components.mammotion",
+        "homeassistant",
+        "homeassistant.components",
+        "pymammotion",
+        "pymammotion.utility",
+    )
+    for name in package_names:
+        package = _module(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "homeassistant.components.image",
+        _module("homeassistant.components.image", ImageEntity=ImageEntity),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "homeassistant.const",
+        _module(
+            "homeassistant.const",
+            EntityCategory=SimpleNamespace(DIAGNOSTIC="diagnostic"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "homeassistant.core",
+        _module(
+            "homeassistant.core",
+            HomeAssistant=object,
+            callback=lambda function: function,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pymammotion.utility.device_type",
+        _module("pymammotion.utility.device_type", DeviceType=DeviceType),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "pymammotion.utility.map_renderer",
+        _module(
+            "pymammotion.utility.map_renderer",
+            placeholder_png=lambda: b"placeholder",
+            render_map_png=Mock(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.mammotion.coordinator",
+        _module(
+            "custom_components.mammotion.coordinator",
+            MammotionReportUpdateCoordinator=object,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.mammotion.entity",
+        _module(
+            "custom_components.mammotion.entity",
+            MammotionBaseEntity=MammotionBaseEntity,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.mammotion.geojson_utils",
+        _module(
+            "custom_components.mammotion.geojson_utils",
+            apply_coord=lambda coordinates, *_args: coordinates,
+            apply_geojson_offset=lambda geojson, *_args: geojson,
+        ),
+    )
+    sys.modules["custom_components.mammotion"].MammotionConfigEntry = object
+
+    name = "custom_components.mammotion.image_under_test"
+    spec = importlib.util.spec_from_file_location(
+        name,
+        Path(__file__).parents[1] / "custom_components/mammotion/image.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _line_geojson() -> dict[str, object]:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            }
+        ],
+    }
+
+
+def test_map_update_invalidates_render_and_geometry_caches(monkeypatch) -> None:
+    """A map callback forces the next image request to rebuild all inputs."""
+    module = _load_image_module(monkeypatch)
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity._cached_png = b"cached"
+    entity._geometry_sources = (object(),)
+    entity._notified_content_key = "old"
+    entity.async_write_ha_state = Mock()
+
+    entity._handle_map_update()
+
+    assert entity._cached_png is None
+    assert entity._geometry_sources is None
+    assert entity._notified_content_key is None
+    entity.async_write_ha_state.assert_called_once_with()
+
+
+def test_render_timeout_fits_home_assistant_image_deadline(monkeypatch) -> None:
+    """Tile rendering yields a fallback before HA abandons the image request."""
+    module = _load_image_module(monkeypatch)
+
+    assert module._IMAGE_RENDER_TIMEOUT < 10
+
+
+@pytest.mark.asyncio
+async def test_render_timeout_rearms_content_invalidation(monkeypatch) -> None:
+    """An unchanged map is announced again after a transient render timeout."""
+    module = _load_image_module(monkeypatch)
+    module.render_map_png = AsyncMock(side_effect=TimeoutError)
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity._render_lock = asyncio.Lock()
+    entity._cached_png = b"cached"
+    entity._last_content_key = "old"
+    entity._notified_content_key = "current"
+    entity._last_render_time = 0.0
+    entity.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *_parts: "/tmp")
+    )
+    entity._image_payload = Mock(
+        return_value=({}, None, "current")
+    )
+
+    assert await entity.async_image() == b"cached"
+    assert entity._notified_content_key is None
+
+
+def test_dynamics_geometry_falls_back_to_native_progress(monkeypatch) -> None:
+    """An unusable dynamics payload cannot hide valid device progress lines."""
+    module = _load_image_module(monkeypatch)
+    progress = _line_geojson()
+    dynamics = {
+        "type": "FeatureCollection",
+        "features": [{"geometry": {"type": "Point", "coordinates": [0, 0]}}],
+    }
+    mower = SimpleNamespace(
+        map=SimpleNamespace(
+            generated_geojson=None,
+            generated_mow_path_geojson=None,
+            generated_dynamics_line_geojson=dynamics,
+            generated_mow_progress_geojson=progress,
+            area_name=[],
+        ),
+        device_firmwares=SimpleNamespace(main_controller="1.0"),
+    )
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity.coordinator = SimpleNamespace(device_name="Yuka-MLYQ73XB")
+
+    assert entity._geojson_sources(mower)[2] is progress
+
+    mower.map.generated_dynamics_line_geojson = _line_geojson()
+    assert (
+        entity._geojson_sources(mower)[2] is mower.map.generated_dynamics_line_geojson
+    )
+
+
+def test_latest_area_name_overlays_cached_map_label(monkeypatch) -> None:
+    """A rename updates rendered labels without mutating cached map geometry."""
+    module = _load_image_module(monkeypatch)
+    base = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {
+                    "type_name": "area",
+                    "hash": 42,
+                    "Name": "Old name",
+                },
+                "geometry": {"type": "Polygon", "coordinates": []},
+            }
+        ],
+    }
+    merged = module.MammotionMapImage._merged_geojson(
+        (base, None, None, ((42, "New name"),))
+    )
+
+    assert merged["features"][0]["properties"]["Name"] == "New name"
+    assert base["features"][0]["properties"]["Name"] == "Old name"
+
+
+def test_equal_area_names_reuse_cached_geometry(monkeypatch) -> None:
+    """Fresh immutable label tuples do not force a geometry rebuild."""
+    module = _load_image_module(monkeypatch)
+    base = {"type": "FeatureCollection", "features": []}
+    mower = SimpleNamespace(
+        map=SimpleNamespace(
+            generated_geojson=base,
+            generated_mow_path_geojson=None,
+            generated_dynamics_line_geojson=None,
+            generated_mow_progress_geojson=None,
+            area_name=[SimpleNamespace(hash=42, name="Garden")],
+        ),
+        device_firmwares=SimpleNamespace(main_controller="1.0"),
+    )
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity.coordinator = SimpleNamespace(device_name="Yuka-MLYQ73XB")
+    entity._geometry_sources = None
+    entity._geometry_offset = None
+    entity._geometry_geojson = None
+    entity._geometry_key = ""
+
+    first, first_key = entity._geometry_payload(mower, 0.0, 0.0)
+    second, second_key = entity._geometry_payload(mower, 0.0, 0.0)
+
+    assert second is first
+    assert second_key == first_key
+
+
+def test_restored_complete_map_remains_renderable_while_docked(monkeypatch) -> None:
+    """A restored complete map and trail must not be replaced by a placeholder."""
+    module = _load_image_module(monkeypatch)
+    mower = SimpleNamespace(
+        report_data=SimpleNamespace(
+            dev=SimpleNamespace(sys_status=1),
+            locations=[SimpleNamespace(bol_hash=200)],
+        ),
+        device_firmwares=SimpleNamespace(main_controller="1.0"),
+        map=SimpleNamespace(
+            generated_geojson={
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"type": "area"},
+                        "geometry": {"type": "Polygon", "coordinates": []},
+                    }
+                ]
+            },
+            is_map_synced=lambda _bol_hash: False,
+        ),
+    )
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity.coordinator = SimpleNamespace(
+        device_name="Yuka-MLYQ73XB",
+        map_sync_status="out_of_sync",
+    )
+
+    assert entity._has_renderable_map(mower)
+
+
+def test_non_map_geometry_is_not_renderable(monkeypatch) -> None:
+    """An incomplete payload cannot replace the placeholder before map sync."""
+    module = _load_image_module(monkeypatch)
+    mower = SimpleNamespace(
+        report_data=SimpleNamespace(
+            dev=SimpleNamespace(sys_status=1),
+            locations=[SimpleNamespace(bol_hash=200)],
+        ),
+        map=SimpleNamespace(
+            generated_geojson={"features": [{"type": "Feature"}]},
+            is_map_synced=lambda _bol_hash: False,
+        ),
+    )
+    entity = module.MammotionMapImage.__new__(module.MammotionMapImage)
+    entity.coordinator = SimpleNamespace(map_sync_status="out_of_sync")
+
+    assert not entity._has_renderable_map(mower)
+
+
+def test_content_key_tracks_geometry_and_mower_position(monkeypatch) -> None:
+    """Geometry replacement and meaningful mower movement invalidate the image."""
+    module = _load_image_module(monkeypatch)
+    location = SimpleNamespace(longitude=-0.5032998, latitude=51.1379717)
+    baseline = module.MammotionMapImage._content_key("geometry-a", location)
+
+    jittered = SimpleNamespace(longitude=-0.5032997, latitude=51.1379718)
+    moved = SimpleNamespace(longitude=-0.5032898, latitude=51.1379717)
+    assert module.MammotionMapImage._content_key("geometry-a", jittered) == baseline
+    assert module.MammotionMapImage._content_key("geometry-a", moved) != baseline
+    assert module.MammotionMapImage._content_key("geometry-b", location) != baseline


### PR DESCRIPTION
## What

- add a Mammotion map image platform
- render device GeoJSON with mower position, dock, progress paths and cached OpenStreetMap context
- retain the current or most recently completed GPS trail until the next task starts
- persist trail points locally across Home Assistant restarts

## Why

The integration exposes useful map geometry but no practical Home Assistant map entity. Its live trail also disappeared as soon as a task ended, which made the map much less useful after a mow.

## Validation

- `ruff check --ignore BLE001,D102,TRY300,SIM105,C901 custom_components/mammotion/coordinator.py`
- `python -m compileall -q custom_components/mammotion`
- `git diff --check`
- live Yuka 2 map and trail validation
- verified 292 trail points persisted across a Home Assistant restart