### PR TITLE
mammotion: Treat docked pause as docked

### DIFF
--- a/custom_components/mammotion/lawn_mower.py
+++ b/custom_components/mammotion/lawn_mower.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymammotion.data.model.report_info import DeviceData, ReportData
-from pymammotion.utility.constant.device_constant import WorkMode
+from pymammotion.utility.constant.device_constant import PosType, WorkMode
 from pymammotion.utility.device_type import DeviceType
 
 from . import MammotionConfigEntry
@@ -212,7 +212,20 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
         if mode is None:
             return None
 
+        position_type = self.coordinator.data.location.position_type
         LOGGER.debug("activity mode %s", mode)
+        if mode == WorkMode.MODE_CHARGING_PAUSE:
+            # Charging pause belongs to an unfinished mowing task.
+            return LawnMowerActivity.PAUSED
+        if (
+            mode
+            in (
+                WorkMode.MODE_READY,
+                WorkMode.MODE_PAUSE,
+            )
+            and position_type == PosType.CHARGE_ON.value
+        ):
+            return LawnMowerActivity.DOCKED
         if mode == WorkMode.MODE_PAUSE or (
             mode == WorkMode.MODE_READY and charge_state == 0
         ):
@@ -227,7 +240,7 @@ class MammotionLawnMowerEntity(MammotionBaseEntity, LawnMowerEntity):  # type: i
             return LawnMowerActivity.DOCKED
         return None
 
-    async def async_start_mowing(self, **kwargs: Any) -> None:
+    async def async_start_mowing(self, **kwargs: Any) -> None:  # noqa: C901
         """Start mowing."""
         trans_key = "pause_failed"
 


### PR DESCRIPTION
## What

Treat `MODE_PAUSE` as docked when the mower is physically on the charger.

## Why

Yuka can retain a paused mode at the dock, leaving Home Assistant showing a resumable task when it is actually docked.

## Validation

- `ruff check custom_components/mammotion/lawn_mower.py`
- `ruff format --check custom_components/mammotion/lawn_mower.py`
- `python -m compileall -q custom_components/mammotion/lawn_mower.py`
- Live dock, pause, and charge-state validation
