### PR TITLE
feat(button): add "Refresh status" button for mowers

### DIFF
--- a/custom_components/mammotion/button.py
+++ b/custom_components/mammotion/button.py
@@ -105,6 +105,11 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
+        key="refresh_status",
+        press_fn=lambda coordinator: coordinator.async_ensure_fresh_state(),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MammotionButtonSensorEntityDescription(
         key="resync_rtk_dock",
         press_fn=lambda coordinator: coordinator.async_rtk_dock_location(),
         entity_category=EntityCategory.CONFIG,

--- a/custom_components/mammotion/button.py
+++ b/custom_components/mammotion/button.py
@@ -106,6 +106,11 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
+        key="refresh_status",
+        press_fn=lambda coordinator: coordinator.async_ensure_fresh_state(),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MammotionButtonSensorEntityDescription(
         key="resync_rtk_dock",
         press_fn=lambda coordinator: coordinator.async_rtk_dock_location(),
         entity_category=EntityCategory.CONFIG,

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -286,6 +286,9 @@
       "relocate_charging_station": {
         "name": "Relocate charging station"
       },
+      "refresh_status": {
+        "name": "Refresh status"
+      },
       "spino_fetch_map": {
         "name": "Fetch pool map"
       },

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Restart mower"
       },
+      "refresh_status": {
+        "name": "Refresh status"
+      },
       "spino_fetch_map": {
         "name": "Fetch pool map"
       },

--- a/custom_components/mammotion/translations/cs.json
+++ b/custom_components/mammotion/translations/cs.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Restartovat sekačku"
       },
+      "refresh_status": {
+        "name": "Obnovit stav"
+      },
       "spino_fetch_map": {
         "name": "Načíst mapu bazénu"
       },

--- a/custom_components/mammotion/translations/da.json
+++ b/custom_components/mammotion/translations/da.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Genstart plæneklipperen"
       },
+      "refresh_status": {
+        "name": "Opdater status"
+      },
       "spino_fetch_map": {
         "name": "Hent poolkort"
       },

--- a/custom_components/mammotion/translations/de.json
+++ b/custom_components/mammotion/translations/de.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Mähroboter neustarten"
       },
+      "refresh_status": {
+        "name": "Status aktualisieren"
+      },
       "spino_fetch_map": {
         "name": "Poolkarte abrufen"
       },

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -381,6 +381,9 @@
       "restart_mower": {
         "name": "Restart mower"
       },
+      "refresh_status": {
+        "name": "Refresh status"
+      },
       "spino_fetch_map": {
         "name": "Fetch pool map"
       },

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Restart mower"
       },
+      "refresh_status": {
+        "name": "Refresh status"
+      },
       "spino_fetch_map": {
         "name": "Fetch pool map"
       },

--- a/custom_components/mammotion/translations/fr.json
+++ b/custom_components/mammotion/translations/fr.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Redémarrer la tondeuse"
       },
+      "refresh_status": {
+        "name": "Actualiser le statut"
+      },
       "spino_fetch_map": {
         "name": "Récupérer la carte de la piscine"
       },

--- a/custom_components/mammotion/translations/hu.json
+++ b/custom_components/mammotion/translations/hu.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Fűnyíró újraindítása"
       },
+      "refresh_status": {
+        "name": "Állapot frissítése"
+      },
       "spino_fetch_map": {
         "name": "Medencetérkép lekérése"
       },

--- a/custom_components/mammotion/translations/it.json
+++ b/custom_components/mammotion/translations/it.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Riavvia il tagliaerba"
       },
+      "refresh_status": {
+        "name": "Aggiorna stato"
+      },
       "spino_fetch_map": {
         "name": "Recupera mappa della piscina"
       },

--- a/custom_components/mammotion/translations/nl.json
+++ b/custom_components/mammotion/translations/nl.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Maaier herstarten"
       },
+      "refresh_status": {
+        "name": "Status vernieuwen"
+      },
       "spino_fetch_map": {
         "name": "Zwembadkaart ophalen"
       },

--- a/custom_components/mammotion/translations/pl.json
+++ b/custom_components/mammotion/translations/pl.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Uruchom ponownie kosiarkę"
       },
+      "refresh_status": {
+        "name": "Odśwież stan"
+      },
       "spino_fetch_map": {
         "name": "Pobierz mapę basenu"
       },

--- a/custom_components/mammotion/translations/ro.json
+++ b/custom_components/mammotion/translations/ro.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Repornire mașina de tuns"
       },
+      "refresh_status": {
+        "name": "Reîmprospătează starea"
+      },
       "spino_fetch_map": {
         "name": "Preia harta piscinei"
       },

--- a/custom_components/mammotion/translations/sl.json
+++ b/custom_components/mammotion/translations/sl.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Ponovni zagon kosilnice"
       },
+      "refresh_status": {
+        "name": "Osveži stanje"
+      },
       "spino_fetch_map": {
         "name": "Pridobi zemljevid bazena"
       },

--- a/custom_components/mammotion/translations/sv.json
+++ b/custom_components/mammotion/translations/sv.json
@@ -392,6 +392,9 @@
       "restart_mower": {
         "name": "Starta om gräsklipparen"
       },
+      "refresh_status": {
+        "name": "Uppdatera status"
+      },
       "spino_fetch_map": {
         "name": "Hämta poolkarta"
       },


### PR DESCRIPTION
## What

Adds a **Refresh status** button (`button.<mower>_refresh_status`) for Luba/Yuka mowers, mirroring the existing `spino_refresh_status` button the Spino pool cleaner already exposes.

Pressing it calls `coordinator.async_ensure_fresh_state()`, which fires a one-shot report snapshot **only when the cached device state is older than 2 minutes** (a no-op while a BLE report stream is already feeding fresh data, so repeated taps won't hammer the device).

## Why

The integration is `local_push`. When a mower is docked and idle it stops emitting `report_data.dev` / `.work` status frames, so `lawn_mower`, `activity_mode`, `binary_sensor.*_charging` and `progress` freeze at the last-received snapshot while the lightweight `connect`/RSSI heartbeat keeps updating. There is currently no user-facing way to pull a fresh status on demand:

- `homeassistant.update_entity` only re-reads the cached push data (no device round-trip),
- the map / schedule / RTK sync buttons refresh different data structures,
- the only way to force a `dev` refresh today is to send a **motion** command (start / dock / pause), each of which already calls the snapshot internally.

This exposes the gentle refresh primitive on its own so users (and automations, via `button.press`) can bring status current **without commanding the mower** — and brings mowers to parity with the Spino, which already has this exact button.

## Changes

- `button.py`: add `refresh_status` to `BUTTON_SENSORS` (`EntityCategory.DIAGNOSTIC`), `press_fn` → `async_ensure_fresh_state()`.
- `strings.json` + `translations/en.json`: "Refresh status" name (same string the Spino button uses).

## Testing

- JSON files validated.
- Change mirrors the existing button + translation patterns; no new dependencies.