### PR TITLE
Improve stream subscription failure logging

### DIFF
--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -227,48 +227,59 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):  # ty
                 )
                 return None, self._agora_response
 
-            if stream_data is not None and stream_data.data is not None:
-                LOGGER.debug("Received stream data: %s", stream_data)
+            if stream_data is None or stream_data.data is None:
+                # pymammotion recovers from stream/token 401 internally; if we
+                # still have no data, surface that clearly instead of claiming
+                # the token refresh succeeded.
+                LOGGER.error(
+                    "Stream subscription for %s returned no usable data "
+                    "(response=%s)",
+                    self.device_name,
+                    stream_data,
+                )
+                return None, self._agora_response
 
-                # Get ICE servers from Agora API
-                try:
-                    subscription = stream_data.data.to_dict()
-                    async with AgoraAPIClient() as agora_client:
-                        agora_response = await agora_client.choose_server(
-                            app_id=subscription["appid"],
-                            token=subscription["token"],
-                            channel_name=subscription["channelName"],
-                            user_id=int(subscription["uid"]),
-                            service_flags=[
-                                SERVICE_IDS["CHOOSE_SERVER"],  # Gateway addresses
-                                SERVICE_IDS["CLOUD_PROXY_FALLBACK"],  # TURN servers
-                            ],
-                        )
+            LOGGER.debug("Received stream data: %s", stream_data)
 
-                        # Get ICE servers and convert to RTCIceServer format - use only first TURN server to match SDK (3 entries)
-                        ice_servers_agora = agora_response.get_ice_servers(
-                            use_all_turn_servers=False
-                        )
-                        LOGGER.info("Ice Servers from Agora API:%s", ice_servers_agora)
-                        ice_servers = [
-                            RTCIceServer(
-                                urls=ice_server.urls,
-                                username=ice_server.username,
-                                credential=ice_server.credential,
-                            )
-                            for ice_server in ice_servers_agora
-                        ]
+            # Get ICE servers from Agora API
+            try:
+                subscription = stream_data.data.to_dict()
+                async with AgoraAPIClient() as agora_client:
+                    agora_response = await agora_client.choose_server(
+                        app_id=subscription["appid"],
+                        token=subscription["token"],
+                        channel_name=subscription["channelName"],
+                        user_id=int(subscription["uid"]),
+                        service_flags=[
+                            SERVICE_IDS["CHOOSE_SERVER"],  # Gateway addresses
+                            SERVICE_IDS["CLOUD_PROXY_FALLBACK"],  # TURN servers
+                        ],
+                    )
 
-                        # Store ICE servers in coordinator
-                        self._ice_servers = ice_servers
-                        self._agora_response = agora_response
-                        LOGGER.info(
-                            "Retrieved %d ICE servers from Agora API",
-                            len(ice_servers),
+                    # Get ICE servers and convert to RTCIceServer format - use only first TURN server to match SDK (3 entries)
+                    ice_servers_agora = agora_response.get_ice_servers(
+                        use_all_turn_servers=False
+                    )
+                    LOGGER.info("Ice Servers from Agora API:%s", ice_servers_agora)
+                    ice_servers = [
+                        RTCIceServer(
+                            urls=ice_server.urls,
+                            username=ice_server.username,
+                            credential=ice_server.credential,
                         )
-                except Exception as e:
-                    LOGGER.error("Failed to get ICE servers from Agora API: %s", e)
-                    self._ice_servers = []
+                        for ice_server in ice_servers_agora
+                    ]
+
+                    # Store ICE servers in coordinator
+                    self._ice_servers = ice_servers
+                    self._agora_response = agora_response
+                    LOGGER.info(
+                        "Retrieved %d ICE servers from Agora API",
+                        len(ice_servers),
+                    )
+            except Exception as e:
+                LOGGER.error("Failed to get ICE servers from Agora API: %s", e)
+                self._ice_servers = []
 
             LOGGER.debug("Stream token refreshed successfully")
         except Exception as ex:

--- a/custom_components/mammotion/manifest.json
+++ b/custom_components/mammotion/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mammotion",
   "name": "Mammotion",
-  "version": "0.6.4-beta8",
+  "version": "0.6.4-beta9",
   "issue_tracker": "https://github.com/mikey0000/Mammotion-HA/issues",
   "integration_type": "device",
   "bluetooth": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mammotion-ha"
-version = "0.6.4-beta8"
+version = "0.6.4-beta9"
 description = "Mammotion integration for HACS"
 authors = [
     {name = "Michael Arthur", email = "michael@jumblesoft.co.nz"},


### PR DESCRIPTION
> **Note:** This PR and code fix were generated with AI assistance.

## Summary
- Stop logging `Stream token refreshed successfully` when the cloud returns no usable Agora stream data.
- Log the actual empty/error response instead so failures are diagnosable.
- Version bump to `0.6.4-beta9`.

**Depends on:** the companion PyMammotion fix for stream/token `401` recovery (refresh + retry / regional host fallback). That is the real camera-stream fix; this PR only improves HA-side logging around empty stream responses.

Related: #789

## Test plan
- [ ] With unfixed pymammotion, confirm logs no longer claim success when stream data is empty
- [ ] With the PyMammotion 401-recovery fix installed, confirm camera stream starts and success logging only appears when stream data is present


Made with [Cursor](https://cursor.com)