### PR TITLE
Fix working-number defaults and restore values outside device limits

### DIFF
--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -354,6 +354,10 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
             await self.entity_description.set_async_fn(self.coordinator, value)
         self.async_write_ha_state()
 
+    def _normalize_native_value(self, value: float) -> float:
+        """Return a local value suitable for restoring into this entity."""
+        return value
+
     async def async_added_to_hass(self) -> None:
         """Restore last saved value when entity is added to hass."""
         await super().async_added_to_hass()
@@ -361,7 +365,9 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
         if (last_number_data is not None) and (
             last_number_data.native_value is not None
         ):
-            self._attr_native_value = last_number_data.native_value
+            self._attr_native_value = self._normalize_native_value(
+                last_number_data.native_value
+            )
             if self.entity_description.set_fn is not None:
                 self.entity_description.set_fn(
                     self.coordinator, cast(float, self._attr_native_value)
@@ -393,10 +399,16 @@ class MammotionWorkingNumberEntity(MammotionConfigNumberEntity):
         if self.entity_description.get_fn is not None:
             self._attr_native_value = self.entity_description.get_fn(self.coordinator)
 
-        native_val = self._attr_native_value
-        native_min = self._attr_native_min_value
-        if native_val is not None and native_min is not None:
-            self._attr_native_value = max(native_val, native_min)
+        if self._attr_native_value is not None:
+            self._attr_native_value = self._normalize_native_value(
+                self._attr_native_value
+            )
+            if self.entity_description.set_fn is not None:
+                self.entity_description.set_fn(self.coordinator, self._attr_native_value)
+
+    def _normalize_native_value(self, value: float) -> float:
+        """Keep initial and restored planning values within the model's limits."""
+        return min(max(value, self.native_min_value), self.native_max_value)
 
     @property
     def native_min_value(self) -> float:

--- a/custom_components/mammotion/number.py
+++ b/custom_components/mammotion/number.py
@@ -303,6 +303,11 @@ async def async_setup_entry(
         )
 
 
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    """Return value limited to the inclusive minimum/maximum range."""
+    return min(max(value, minimum), maximum)
+
+
 class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: ignore[misc]
     """Mammotion config number entity."""
 
@@ -354,10 +359,6 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
             await self.entity_description.set_async_fn(self.coordinator, value)
         self.async_write_ha_state()
 
-    def _normalize_native_value(self, value: float) -> float:
-        """Return a local value suitable for restoring into this entity."""
-        return value
-
     async def async_added_to_hass(self) -> None:
         """Restore last saved value when entity is added to hass."""
         await super().async_added_to_hass()
@@ -365,8 +366,10 @@ class MammotionConfigNumberEntity(MammotionBaseEntity, RestoreNumber):  # type: 
         if (last_number_data is not None) and (
             last_number_data.native_value is not None
         ):
-            self._attr_native_value = self._normalize_native_value(
-                last_number_data.native_value
+            self._attr_native_value = _clamp(
+                last_number_data.native_value,
+                self.native_min_value,
+                self.native_max_value,
             )
             if self.entity_description.set_fn is not None:
                 self.entity_description.set_fn(
@@ -400,15 +403,15 @@ class MammotionWorkingNumberEntity(MammotionConfigNumberEntity):
             self._attr_native_value = self.entity_description.get_fn(self.coordinator)
 
         if self._attr_native_value is not None:
-            self._attr_native_value = self._normalize_native_value(
-                self._attr_native_value
+            self._attr_native_value = _clamp(
+                self._attr_native_value,
+                self.native_min_value,
+                self.native_max_value,
             )
             if self.entity_description.set_fn is not None:
-                self.entity_description.set_fn(self.coordinator, self._attr_native_value)
-
-    def _normalize_native_value(self, value: float) -> float:
-        """Keep initial and restored planning values within the model's limits."""
-        return min(max(value, self.native_min_value), self.native_max_value)
+                self.entity_description.set_fn(
+                    self.coordinator, self._attr_native_value
+                )
 
     @property
     def native_min_value(self) -> float:

--- a/tests/test_number_device_limits.py
+++ b/tests/test_number_device_limits.py
@@ -10,10 +10,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+WANTED = {"_clamp", "MammotionConfigNumberEntity", "MammotionWorkingNumberEntity"}
 
-@pytest.fixture
-def number_class():
-    """Load the real number classes with only their HA boundaries replaced."""
+
+def _load_number_namespace():
+    """Load the real number entities with only their HA boundaries replaced."""
 
     class BaseEntity:
         def __init__(self, coordinator, key):
@@ -28,15 +29,22 @@ def number_class():
             pass
 
     class RestoreNumber:
-        pass
+        """Stand in for the HA mixin, including its native_min/max defaults."""
+
+        @property
+        def native_min_value(self) -> float:
+            return self._attr_native_min_value
+
+        @property
+        def native_max_value(self) -> float:
+            return self._attr_native_max_value
 
     source = Path(__file__).parent.parent / "custom_components/mammotion/number.py"
     tree = ast.parse(source.read_text())
     tree.body = [
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef)
-        and node.name in {"MammotionConfigNumberEntity", "MammotionWorkingNumberEntity"}
+        if isinstance(node, ast.ClassDef | ast.FunctionDef) and node.name in WANTED
     ]
     namespace = {
         "Any": Any,
@@ -51,7 +59,19 @@ def number_class():
         "DEGREE": "°",
     }
     exec(compile(tree, str(source), "exec"), namespace)  # noqa: S102
-    return namespace["MammotionWorkingNumberEntity"]
+    return namespace
+
+
+@pytest.fixture
+def number_class():
+    """Return the working number entity under test."""
+    return _load_number_namespace()["MammotionWorkingNumberEntity"]
+
+
+@pytest.fixture
+def config_number_class():
+    """Return the plain config number entity under test."""
+    return _load_number_namespace()["MammotionConfigNumberEntity"]
 
 
 def make_number(number_class, *, minimum=8, maximum=14, height=None):
@@ -133,3 +153,30 @@ def test_no_device_limits_uses_description(number_class):
     assert number.native_min_value == 20
     assert number.native_max_value == 35
     assert number._attr_native_value == settings.channel_width == 20
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(("saved", "expected"), [(150, 100), (-10, 0), (42, 42)])
+async def test_config_restore_respects_its_own_range(
+    config_number_class, saved, expected
+):
+    """A config number restores inside the range it advertises to HA."""
+    settings = SimpleNamespace(cutter_height=0)
+    coordinator = SimpleNamespace(operation_settings=settings)
+    description = SimpleNamespace(
+        key="cutter_height",
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        native_unit_of_measurement="%",
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, "cutter_height", value
+        ),
+        get_fn=None,
+        set_async_fn=AsyncMock(),
+    )
+    number = config_number_class(coordinator, description)
+    number.async_get_last_number_data.return_value = SimpleNamespace(native_value=saved)
+    await number.async_added_to_hass()
+    assert number._attr_native_value == expected
+    assert settings.cutter_height == expected

--- a/tests/test_number_device_limits.py
+++ b/tests/test_number_device_limits.py
@@ -1,0 +1,135 @@
+"""Working numbers must keep model limits, displayed values and plans consistent."""
+
+# ruff: noqa: INP001, SLF001
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def number_class():
+    """Load the real number classes with only their HA boundaries replaced."""
+
+    class BaseEntity:
+        def __init__(self, coordinator, key):
+            self.coordinator = coordinator
+            self.async_get_last_number_data = AsyncMock(return_value=None)
+            self.async_write_ha_state = Mock()
+
+        async def async_added_to_hass(self):
+            pass
+
+        def _handle_coordinator_update(self):
+            pass
+
+    class RestoreNumber:
+        pass
+
+    source = Path(__file__).parent.parent / "custom_components/mammotion/number.py"
+    tree = ast.parse(source.read_text())
+    tree.body = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name in {"MammotionConfigNumberEntity", "MammotionWorkingNumberEntity"}
+    ]
+    namespace = {
+        "Any": Any,
+        "cast": cast,
+        "MammotionBaseEntity": BaseEntity,
+        "RestoreNumber": RestoreNumber,
+        "MammotionBaseUpdateCoordinator": list,
+        "MammotionConfigNumberEntityDescription": SimpleNamespace,
+        "DeviceLimits": SimpleNamespace,
+        "EntityCategory": SimpleNamespace(CONFIG="config"),
+        "callback": lambda function: function,
+        "DEGREE": "°",
+    }
+    exec(compile(tree, str(source), "exec"), namespace)  # noqa: S102
+    return namespace["MammotionWorkingNumberEntity"]
+
+
+def make_number(number_class, *, minimum=8, maximum=14, height=None):
+    """Use Mini limits with the integration's generic planning defaults."""
+    settings = SimpleNamespace(channel_width=20, blade_height=height)
+    coordinator = SimpleNamespace(operation_settings=settings)
+    key, field = (
+        ("path_spacing", "channel_width")
+        if height is None
+        else ("blade_height", "blade_height")
+    )
+    description = SimpleNamespace(
+        key=key,
+        native_min_value=20 if height is None else 25,
+        native_max_value=35 if height is None else 70,
+        native_step=1,
+        native_unit_of_measurement="cm" if height is None else "mm",
+        set_fn=lambda coordinator, value: setattr(
+            coordinator.operation_settings, field, value
+        ),
+        get_fn=None
+        if height is None
+        else lambda coordinator: coordinator.operation_settings.blade_height,
+        set_async_fn=AsyncMock(),
+    )
+    limits = SimpleNamespace(**{key: SimpleNamespace(min=minimum, max=maximum)})
+    return number_class(coordinator, description, limits), settings
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum", "expected"), [(8, 14, 14), (25, 35, 25), (20, 35, 20)]
+)
+def test_initial_spacing_uses_device_limits(number_class, minimum, maximum, expected):
+    """Defaults respect both ends of the model range and update the plan."""
+    number, settings = make_number(number_class, minimum=minimum, maximum=maximum)
+    assert number._attr_native_value == expected
+    assert settings.channel_width == expected
+    number.entity_description.set_async_fn.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(("saved", "expected"), [(35, 14), (5, 8), (12, 12)])
+async def test_restore_validates_before_updating_plan(number_class, saved, expected):
+    """Only a normalized value reaches the planning setter during restore."""
+    number, settings = make_number(number_class)
+    number.async_get_last_number_data.return_value = SimpleNamespace(native_value=saved)
+    setter = Mock(wraps=number.entity_description.set_fn)
+    number.entity_description.set_fn = setter
+    await number.async_added_to_hass()
+    assert number._attr_native_value == expected
+    assert settings.channel_width == expected
+    setter.assert_called_once_with(number.coordinator, expected)
+    number.entity_description.set_async_fn.assert_not_called()
+
+
+@pytest.mark.parametrize(("height", "expected"), [(0, 20), (65, 65), (70, 65)])
+def test_initial_height_survives_coordinator_update(number_class, height, expected):
+    """An update cannot undo the normalized initial height."""
+    number, settings = make_number(number_class, minimum=20, maximum=65, height=height)
+    assert number._attr_native_value == expected
+    assert settings.blade_height == expected
+    number._handle_coordinator_update()
+    assert number._attr_native_value == expected
+    number.entity_description.set_async_fn.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_missing_restore_keeps_initialized_value(number_class):
+    """A first installation retains its model-specific initial value."""
+    number, settings = make_number(number_class)
+    await number.async_added_to_hass()
+    assert number._attr_native_value == settings.channel_width == 14
+
+
+def test_no_device_limits_uses_description(number_class):
+    """Missing model metadata retains the generic range and default."""
+    template, settings = make_number(number_class)
+    number = number_class(template.coordinator, template.entity_description, None)
+    assert number.native_min_value == 20
+    assert number.native_max_value == 35
+    assert number._attr_native_value == settings.channel_width == 20


### PR DESCRIPTION
Working number entities can start or restore outside their model's own range. On a LUBA mini, the path-spacing entity advertises 8–14 cm but starts at 20 cm. Initialization only clamps the minimum, and even that correction is not copied back into `operation_settings`. For blade height, a subsequent coordinator update therefore restores the invalid planning value of 0 to the display.

This normalizes initial and restored working-number values against both device limits and keeps the local planning value consistent. Valid restored values are preserved. Initialization and restoration do not invoke the asynchronous mower callback. The existing minimum-clamp policy is retained and synchronized with the plan; this does not replace planning values with live mower telemetry or restrict explicit `start_mow` service parameters.

Related to #586: model limits are now available, but local defaults and restored values still bypass them. This addresses that remaining number-entity issue rather than changing firmware-side clamping. Also related to the invalid planning values discussed in #856; the running-route preservation changes already on main are left intact.

Validation on Python 3.14.4:
- 11 new regression cases covering both model bounds, valid/invalid restore, missing restore, missing model limits and height consistency after coordinator updates. Before the fix, 7 of the original 10 cases failed; after the fix all 11 pass.
- New tests plus existing `test_blade_height_running_job.py`: 21 passed.
- Full suite: 224 passed, with the same 2 failures and 6 errors as unmodified main (invalid `translations/de.json`, already addressed by #875, and an external GeoJSON fixture missing from this repository).
- Ruff passes for the new test file; number.py passes excluding existing C901/PERF401 findings in unchanged setup code. `git diff --check` passes.

Tests execute the actual entity classes with HA/transport boundaries stubbed, following the existing test suite's approach. No physical mower operation was performed.
