### PR TITLE
Bundle synthetic GeoJSON fixture for standalone map offset tests

### DIFF
--- a/tests/fixtures/mow_progress.geojson
+++ b/tests/fixtures/mow_progress.geojson
@@ -1,0 +1,29 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Synthetic southern pass", "progress": 25},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[175.0, -38.0], [175.0001, -37.9999], [175.0002, -37.9998]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Synthetic northern pass", "progress": 50},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[10.0, 60.0], [10.0001, 60.0001], [10.0002, 60.0002]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"name": "Synthetic equatorial pass", "progress": 75},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[0.0, 0.0], [0.0001, 0.0001], [0.0002, 0.0002]]
+      }
+    }
+  ]
+}

--- a/tests/test_geojson_offset.py
+++ b/tests/test_geojson_offset.py
@@ -22,14 +22,14 @@ apply_coord = _mod.apply_coord
 apply_geojson_offset = _mod.apply_geojson_offset
 offset_geometry = _mod.offset_geometry
 
-GEOJSON_PATH = Path(__file__).parent.parent.parent / "Luba-API" / "examples" / "dev_output" / "mow_progress_1.geojson"
+GEOJSON_PATH = Path(__file__).parent / "fixtures" / "mow_progress.geojson"
 
 METERS_PER_DEGREE = 111_111.0
 
 
 @pytest.fixture()
 def mow_progress_geojson() -> dict[str, Any]:
-    """Load the real mow-progress GeoJSON sample."""
+    """Load the synthetic mow-progress sample bundled with this repository."""
     return json.loads(GEOJSON_PATH.read_text())
 
 
@@ -198,8 +198,8 @@ class TestApplyGeojsonOffset:
         result = apply_geojson_offset(g, 10.0, 0.0)
         assert result["coordinates"][1] == pytest.approx(-38.0 + 10.0 / METERS_PER_DEGREE, rel=1e-9)
 
-    def test_real_file_all_features_shifted(self, mow_progress_geojson):
-        """All 14 LineString features in the sample must have every coordinate shifted correctly."""
+    def test_sample_all_features_shifted(self, mow_progress_geojson):
+        """Every coordinate in each sample LineString must shift correctly."""
         lat_offset_m = -13.8
         lon_offset_m = -13.3
         result = apply_geojson_offset(mow_progress_geojson, lat_offset_m, lon_offset_m)


### PR DESCRIPTION
Six map-offset tests fail in a fresh checkout because their fixture points outside this repository to `../Luba-API/examples/dev_output/mow_progress_1.geojson`.

Bundle a small synthetic GeoJSON FeatureCollection in `tests/fixtures` and point the existing tests at it. The sample includes three LineStrings at southern, northern and equatorial latitudes, with properties and multiple coordinates, so the existing coordinate-shift, property-preservation and non-mutation assertions continue to run. No private mower locations or device exports are included.

Validation: `python -m pytest -q tests/test_geojson_offset.py` — 26 passed, compared with 20 passed and 6 fixture errors on unmodified main. `git diff --check` passes. This changes test data only.
